### PR TITLE
Fix/v15/code storage

### DIFF
--- a/css/custom-field-maker.css
+++ b/css/custom-field-maker.css
@@ -116,15 +116,21 @@
 /* アコーディオン
 -------------------------------------- */
 .customFieldAccordionContent {
-  overflow: hidden;
   visibility: hidden;
-  transition: max-height 0.3s ease-out, opacity 0.3s ease-out;
   opacity: 0;
+  display: none;
+  transition:
+    opacity 0.3s ease-out,
+    visibility 0s linear 0.3s;
 }
 
 .customFieldAccordionContent.-open {
   visibility: visible;
   opacity: 1;
+  display: block;
+  transition:
+    opacity 0.3s ease-out,
+    visibility 0s linear;
 }
 
 /* ナビゲーター：コード操作

--- a/css/custom-field-maker.css
+++ b/css/custom-field-maker.css
@@ -120,11 +120,11 @@
   transition: 0.3s;
   transition-property: grid-template-rows;
 }
-.customFieldAccordionContent[aria-hidden=false] {
+.customFieldAccordionContent[aria-hidden=true] {
   grid-template-rows: 0fr;
 }
 
-.customFieldAccordionContent[aria-hidden=true] {
+.customFieldAccordionContent[aria-hidden=false] {
   grid-template-rows: 1fr;
 }
 .customFieldAccordionContent__inner {
@@ -579,4 +579,8 @@
   width: 18px;
   height: auto;
   vertical-align: middle;
+}
+
+.customFIeldmakerHeilighter {
+  margin: 0;
 }

--- a/css/custom-field-maker.css
+++ b/css/custom-field-maker.css
@@ -116,21 +116,19 @@
 /* アコーディオン
 -------------------------------------- */
 .customFieldAccordionContent {
-  visibility: hidden;
-  opacity: 0;
-  display: none;
-  transition:
-    opacity 0.3s ease-out,
-    visibility 0s linear 0.3s;
+  display: grid;
+  transition: 0.3s;
+  transition-property: grid-template-rows;
+}
+.customFieldAccordionContent[aria-hidden=false] {
+  grid-template-rows: 0fr;
 }
 
-.customFieldAccordionContent.-open {
-  visibility: visible;
-  opacity: 1;
-  display: block;
-  transition:
-    opacity 0.3s ease-out,
-    visibility 0s linear;
+.customFieldAccordionContent[aria-hidden=true] {
+  grid-template-rows: 1fr;
+}
+.customFieldAccordionContent__inner {
+  overflow: hidden;
 }
 
 /* ナビゲーター：コード操作

--- a/css/custom-field-maker.css
+++ b/css/custom-field-maker.css
@@ -144,7 +144,7 @@
 -------------------------------------- */
 .customFieldCopied {
   position: absolute;
-  bottom: -40px;
+  bottom: -52px;
   left: -30px;
   background-color: rgba(0, 0, 0, .5);
   font-size: 10px;

--- a/src/components/Highlighter.jsx
+++ b/src/components/Highlighter.jsx
@@ -14,7 +14,7 @@ hljs.configure({
 });
 
 export function Highlighter({ children, onHighlight = () => {} }) {
-  const [source, setSource] = useState('');
+  const [rawSource, setRawSource] = useState('');
 
   const buildSource = useCallback(
     (reactNode) => {
@@ -29,14 +29,14 @@ export function Highlighter({ children, onHighlight = () => {} }) {
       });
 
       const { value = '', code = '' } = hljs.highlight(html, { language: 'xml' });
-      if (source !== value) {
-        setSource(value);
+      if (rawSource !== value) {
+        setRawSource(value);
         if (onHighlight) {
           onHighlight(code);
         }
       }
     },
-    [onHighlight, source]
+    [onHighlight, rawSource]
   );
 
   useEffect(() => {
@@ -48,7 +48,7 @@ export function Highlighter({ children, onHighlight = () => {} }) {
       <pre className="acms-admin-customfield-maker customFIeldmakerHeilighter">
         <code
           className="html twig acms-admin-hljs"
-          dangerouslySetInnerHTML={{ __html: source.replace(/class="hljs-/g, 'class="acms-admin-hljs-') }}
+          dangerouslySetInnerHTML={{ __html: rawSource.replace(/class="hljs-/g, 'class="acms-admin-hljs-') }}
         />
       </pre>
     </div>

--- a/src/components/Highlighter.jsx
+++ b/src/components/Highlighter.jsx
@@ -45,7 +45,7 @@ export function Highlighter({ children, onHighlight = () => {} }) {
 
   return (
     <div>
-      <pre className="acms-admin-customfield-maker">
+      <pre className="acms-admin-customfield-maker customFIeldmakerHeilighter">
         <code
           className="html twig acms-admin-hljs"
           dangerouslySetInnerHTML={{ __html: source.replace(/class="hljs-/g, 'class="acms-admin-hljs-') }}

--- a/src/components/generator/base/Validator.jsx
+++ b/src/components/generator/base/Validator.jsx
@@ -93,7 +93,7 @@ export function Validator(props) {
         </button>
       </div>
 
-      <div className="customFieldAccordionContent" aria-hidden={openValidator ? 'true' : 'false'} ref={contentRef}>
+      <div className="customFieldAccordionContent" aria-hidden={openValidator ? 'false' : 'true'} ref={contentRef}>
         <div className="customFieldAccordionContent__inner">
           <div className="customFieldValidatorArea">
             {isConverter && (

--- a/src/components/generator/base/Validator.jsx
+++ b/src/components/generator/base/Validator.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef, useEffect, useMemo, useCallback } from 'react';
+import React, { useRef, useMemo, useCallback } from 'react';
 import Tooltip from '../../Tooltip';
 import { NoSearchBox } from './NoSearchBox';
 import { useMakerContext } from '../../../store/MakerContext';
@@ -12,47 +12,7 @@ export function Validator(props) {
     preview: { mode },
   } = useMakerContext();
 
-  const [height, setHeight] = useState(0);
   const contentRef = useRef(null);
-
-  const updateHeight = useCallback(() => {
-    if (contentRef.current) {
-      let newHeight;
-      if (openValidator) {
-        newHeight = `${contentRef.current.scrollHeight}px`;
-      } else {
-        newHeight = '0px';
-      }
-      setHeight(newHeight);
-    }
-  }, [openValidator]);
-
-  useEffect(() => {
-    updateHeight();
-
-    window.addEventListener('resize', updateHeight);
-
-    const resizeObserver = new ResizeObserver((entries) => {
-      const currentRef = contentRef.current;
-      for (let entry of entries) {
-        if (entry.target === currentRef) {
-          updateHeight();
-        }
-      }
-    });
-
-    const currentRef = contentRef.current;
-    if (currentRef) {
-      resizeObserver.observe(currentRef);
-    }
-
-    return () => {
-      window.removeEventListener('resize', updateHeight);
-      if (currentRef) {
-        resizeObserver.unobserve(currentRef);
-      }
-    };
-  }, [updateHeight]);
 
   const isConverter = useMemo(() => {
     const possibleConverter = [
@@ -94,9 +54,7 @@ export function Validator(props) {
         },
       ],
     }));
-    // 要素追加後に高さを更新
-    setTimeout(updateHeight, 0);
-  }, [setField, updateHeight]);
+  }, [setField]);
 
   const updateValidatorValue = (idx, value) => {
     const item = validator[idx];
@@ -135,11 +93,7 @@ export function Validator(props) {
         </button>
       </div>
 
-      <div
-        className={`customFieldAccordionContent ${openValidator ? '-open' : ''}`}
-        style={{ maxHeight: height }}
-        ref={contentRef}
-      >
+      <div className={`customFieldAccordionContent ${openValidator ? '-open' : ''}`} ref={contentRef}>
         <div className="customFieldValidatorArea">
           {isConverter && (
             <div>

--- a/src/components/generator/base/Validator.jsx
+++ b/src/components/generator/base/Validator.jsx
@@ -93,152 +93,154 @@ export function Validator(props) {
         </button>
       </div>
 
-      <div className={`customFieldAccordionContent ${openValidator ? '-open' : ''}`} ref={contentRef}>
-        <div className="customFieldValidatorArea">
-          {isConverter && (
-            <div>
-              <div className="customFieldBold">
-                コンバーター
-                <i className="acms-admin-icon-tooltip" data-tooltip-id="convert-tip" />
-                <Tooltip id="convert-tip" place="top" variant="dark">
-                  <span>
-                    テキストフィールドに入力された値を別の値に変換します。詳しくは参照ボタンを押すと表示されるモーダルウィンドウに情報が記載されています。
-                  </span>
-                </Tooltip>
-              </div>
+      <div className="customFieldAccordionContent" aria-hidden={openValidator ? 'true' : 'false'} ref={contentRef}>
+        <div className="customFieldAccordionContent__inner">
+          <div className="customFieldValidatorArea">
+            {isConverter && (
               <div>
-                <input
-                  type="text"
-                  value={converter}
-                  onChange={(e) => {
-                    const value = e.target.value;
-                    setField((prevState) => ({ ...prevState, converter: value }));
-                  }}
-                  className="acms-admin-form-width-quarter acms-admin-margin-right-small"
-                  placeholder="例）rs"
-                />
-                <button
-                  className="acms-admin-btn"
-                  onClick={() => setField((prevState) => ({ ...prevState, openConverter: true }))}
-                >
-                  参照
-                </button>
+                <div className="customFieldBold">
+                  コンバーター
+                  <i className="acms-admin-icon-tooltip" data-tooltip-id="convert-tip" />
+                  <Tooltip id="convert-tip" place="top" variant="dark">
+                    <span>
+                      テキストフィールドに入力された値を別の値に変換します。詳しくは参照ボタンを押すと表示されるモーダルウィンドウに情報が記載されています。
+                    </span>
+                  </Tooltip>
+                </div>
+                <div>
+                  <input
+                    type="text"
+                    value={converter}
+                    onChange={(e) => {
+                      const value = e.target.value;
+                      setField((prevState) => ({ ...prevState, converter: value }));
+                    }}
+                    className="acms-admin-form-width-quarter acms-admin-margin-right-small"
+                    placeholder="例）rs"
+                  />
+                  <button
+                    className="acms-admin-btn"
+                    onClick={() => setField((prevState) => ({ ...prevState, openConverter: true }))}
+                  >
+                    参照
+                  </button>
+                </div>
               </div>
-            </div>
-          )}
+            )}
 
-          {(mode === 'customfield' || mode === 'fieldgroup') && (
-            <>
-              <table className="acms-admin-table customFieldOptionTable" style={{ borderTop: 0 }}>
-                <tbody>
-                  <tr>
-                    <th>
-                      バリデーター
-                      <i className="acms-admin-icon-tooltip" data-tooltip-id="validate-tip" />
-                      <Tooltip id="validate-tip" place="top" variant="dark">
-                        <span>フィールドに入力された値が条件に合っているかをチェックします。</span>
-                      </Tooltip>
-                    </th>
-                    <th>
-                      値
-                      <i className="acms-admin-icon-tooltip" data-tooltip-id="validate-value-tip" />
-                      <Tooltip id="validate-value-tip" place="top" variant="dark">
-                        <span>最小文字数や、正規表現チェックをバリデータに設定した際に設定する値となります。</span>
-                      </Tooltip>
-                    </th>
-                    <th>
-                      メッセージ
-                      <i className="acms-admin-icon-tooltip" data-tooltip-id="validate-message-tip" />
-                      <Tooltip id="validate-message-tip" place="top" variant="dark">
-                        <span>
-                          フィールドに入力されている値が条件に合わなかった場合に表示されるメッセージになります。
-                        </span>
-                      </Tooltip>
-                    </th>
-                    <th />
-                  </tr>
-                  {validator &&
-                    validator.map((item, idx) => (
-                      <tr key={`validator${idx}`}>
-                        <td>
-                          <select
-                            className="acms-admin-form-width-full"
-                            onChange={(e) => {
-                              const value = e.target.value;
-                              updateValidatorOption(idx, value);
-                            }}
-                          >
-                            <option value="">▼ 選択</option>
-                            <optgroup label="入力値の制限">
-                              <option value="required">必須 ( required )</option>
-                              <option value="minlength">最小文字数 ( minlength )</option>
-                              <option value="maxlength">最大文字数 ( maxlength )</option>
-                              <option value="min">下限値 ( min )</option>
-                              <option value="max">上限値 ( max )</option>
-                            </optgroup>
-                            <optgroup label="形式チェック">
-                              <option value="digits">数字チェック ( digits )</option>
-                              <option value="email">メールアドレスチェック ( email )</option>
-                              <option value="hiragana">ひらがなチェック ( hiragana )</option>
-                              <option value="katakana">カタカナチェック ( katakana )</option>
-                              <option value="url">URLチェック ( url )</option>
-                              <option value="dates">日付チェック ( dates )</option>
-                              <option value="times">時間チェック ( times )</option>
-                              <option value="regex">正規表現マッチ ( regex )</option>
-                            </optgroup>
-                          </select>
-                        </td>
-                        <td>
-                          <input
-                            type="text"
-                            defaultValue={item.value}
-                            onInput={(e) => {
-                              const value = e.target.value;
-                              if (!value) return;
-                              updateValidatorValue(idx, value);
-                            }}
-                            className="acms-admin-form-width-full"
-                            disabled={!possibleValidatorValue(item.option)}
-                          />
-                        </td>
-                        <td>
-                          <input
-                            type="text"
-                            defaultValue={item.message}
-                            onInput={(e) => {
-                              const value = e.target.value;
-                              if (!value) return;
-                              updateValidatorMessage(idx, value);
-                            }}
-                            className="acms-admin-form-width-full"
-                          />
-                        </td>
-                        <td>
-                          <button
-                            onClick={() => {
-                              removeValidator(idx);
-                            }}
-                            className="acms-admin-btn-admin acms-admin-btn-admin-danger"
-                          >
-                            削除
-                          </button>
-                        </td>
-                      </tr>
-                    ))}
-                </tbody>
-              </table>
+            {(mode === 'customfield' || mode === 'fieldgroup') && (
+              <>
+                <table className="acms-admin-table customFieldOptionTable" style={{ borderTop: 0 }}>
+                  <tbody>
+                    <tr>
+                      <th>
+                        バリデーター
+                        <i className="acms-admin-icon-tooltip" data-tooltip-id="validate-tip" />
+                        <Tooltip id="validate-tip" place="top" variant="dark">
+                          <span>フィールドに入力された値が条件に合っているかをチェックします。</span>
+                        </Tooltip>
+                      </th>
+                      <th>
+                        値
+                        <i className="acms-admin-icon-tooltip" data-tooltip-id="validate-value-tip" />
+                        <Tooltip id="validate-value-tip" place="top" variant="dark">
+                          <span>最小文字数や、正規表現チェックをバリデータに設定した際に設定する値となります。</span>
+                        </Tooltip>
+                      </th>
+                      <th>
+                        メッセージ
+                        <i className="acms-admin-icon-tooltip" data-tooltip-id="validate-message-tip" />
+                        <Tooltip id="validate-message-tip" place="top" variant="dark">
+                          <span>
+                            フィールドに入力されている値が条件に合わなかった場合に表示されるメッセージになります。
+                          </span>
+                        </Tooltip>
+                      </th>
+                      <th />
+                    </tr>
+                    {validator &&
+                      validator.map((item, idx) => (
+                        <tr key={`validator${idx}`}>
+                          <td>
+                            <select
+                              className="acms-admin-form-width-full"
+                              onChange={(e) => {
+                                const value = e.target.value;
+                                updateValidatorOption(idx, value);
+                              }}
+                            >
+                              <option value="">▼ 選択</option>
+                              <optgroup label="入力値の制限">
+                                <option value="required">必須 ( required )</option>
+                                <option value="minlength">最小文字数 ( minlength )</option>
+                                <option value="maxlength">最大文字数 ( maxlength )</option>
+                                <option value="min">下限値 ( min )</option>
+                                <option value="max">上限値 ( max )</option>
+                              </optgroup>
+                              <optgroup label="形式チェック">
+                                <option value="digits">数字チェック ( digits )</option>
+                                <option value="email">メールアドレスチェック ( email )</option>
+                                <option value="hiragana">ひらがなチェック ( hiragana )</option>
+                                <option value="katakana">カタカナチェック ( katakana )</option>
+                                <option value="url">URLチェック ( url )</option>
+                                <option value="dates">日付チェック ( dates )</option>
+                                <option value="times">時間チェック ( times )</option>
+                                <option value="regex">正規表現マッチ ( regex )</option>
+                              </optgroup>
+                            </select>
+                          </td>
+                          <td>
+                            <input
+                              type="text"
+                              defaultValue={item.value}
+                              onInput={(e) => {
+                                const value = e.target.value;
+                                if (!value) return;
+                                updateValidatorValue(idx, value);
+                              }}
+                              className="acms-admin-form-width-full"
+                              disabled={!possibleValidatorValue(item.option)}
+                            />
+                          </td>
+                          <td>
+                            <input
+                              type="text"
+                              defaultValue={item.message}
+                              onInput={(e) => {
+                                const value = e.target.value;
+                                if (!value) return;
+                                updateValidatorMessage(idx, value);
+                              }}
+                              className="acms-admin-form-width-full"
+                            />
+                          </td>
+                          <td>
+                            <button
+                              onClick={() => {
+                                removeValidator(idx);
+                              }}
+                              className="acms-admin-btn-admin acms-admin-btn-admin-danger"
+                            >
+                              削除
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                  </tbody>
+                </table>
 
-              <div>
-                <button onClick={addValidator} className="acms-admin-btn">
-                  追加
-                </button>
-              </div>
-            </>
-          )}
+                <div>
+                  <button onClick={addValidator} className="acms-admin-btn">
+                    追加
+                  </button>
+                </div>
+              </>
+            )}
 
-          {/text|number|tel|email|password|textarea|radioButton|selectbox/.exec(type) && (
-            <NoSearchBox noSearch={noSearch} setField={setField} />
-          )}
+            {/text|number|tel|email|password|textarea|radioButton|selectbox/.exec(type) && (
+              <NoSearchBox noSearch={noSearch} setField={setField} />
+            )}
+          </div>
         </div>
       </div>
     </div>

--- a/src/components/html/Checkbox.jsx
+++ b/src/components/html/Checkbox.jsx
@@ -48,7 +48,7 @@ export function Checkbox(props) {
             if (!option.label) {
               return null;
             }
-            const id = `${item.name}-${generateSafeId(option.value)}`;
+            const id = `${item.name}-${generateSafeId(option.value)}[]`;
             return (
               <div key={index} className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
                 <input
@@ -105,7 +105,7 @@ export function Checkbox(props) {
             if (!option.label) {
               return null;
             }
-            const id = `${item.name}-${generateSafeId(option.value)}-{id}`;
+            const id = `${item.name}-${generateSafeId(option.value)}-{id}[]`;
             return (
               <div key={index} className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
                 <input

--- a/src/components/html/Checkbox.jsx
+++ b/src/components/html/Checkbox.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { useMakerContext } from '../../store/MakerContext';
 import { OptionValidator } from './OptionValidator';
 import { OptionNoSearch } from './OptionNoSearch';
+import { generateSafeId } from '../../utils';
 
 export function Checkbox(props) {
   const { item, isChecked = true } = props;
@@ -18,16 +19,17 @@ export function Checkbox(props) {
             if (!option.label) {
               return null;
             }
+            const id = `${item.name}-${generateSafeId(option.value)}`;
             return (
               <div key={index} className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
                 <input
+                  id={id}
                   type="checkbox"
                   name={`${item.name}[]`}
                   value={option.value}
                   data-tmp={`{${item.name}:checked#${option.value}}`}
-                  id={`input-checkbox-${item.name}-${option.value}`}
                 />
-                <label htmlFor={`input-checkbox-${item.name}-${option.value}`}>
+                <label htmlFor={id}>
                   <i className="acms-admin-ico-checkbox" />
                   {option.label}
                 </label>
@@ -46,18 +48,19 @@ export function Checkbox(props) {
             if (!option.label) {
               return null;
             }
+            const id = `${item.name}-${generateSafeId(option.value)}`;
             return (
               <div key={index} className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
                 <input
+                  id={id}
                   type="checkbox"
                   name={`${item.name}[]`}
                   value={option.value}
                   {...(isChecked && {
                     'data-tmp': `{${item.name}:checked#${option.value}}`,
                   })}
-                  id={`input-checkbox-${item.name}-${option.value}`}
                 />
-                <label htmlFor={`input-checkbox-${item.name}-${option.value}`}>
+                <label htmlFor={id}>
                   <i className="acms-admin-ico-checkbox" />
                   {option.label}
                 </label>
@@ -73,6 +76,7 @@ export function Checkbox(props) {
             if (!option.label) {
               return null;
             }
+            const id = `${item.name}-${generateSafeId(option.value)}-{id}`;
             return (
               <div key={index} className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
                 <input
@@ -80,9 +84,9 @@ export function Checkbox(props) {
                   name={`${item.name}{id}[]`}
                   value={option.value}
                   data-tmp={`{${item.name}:checked#${option.value}}`}
-                  id={`input-checkbox-${item.name}-${option.value}-{id}`}
+                  id={id}
                 />
-                <label htmlFor={`input-checkbox-${item.name}-${option.value}-{id}`}>
+                <label htmlFor={id}>
                   <i className="acms-admin-ico-checkbox" />
                   {option.label}
                 </label>
@@ -101,18 +105,19 @@ export function Checkbox(props) {
             if (!option.label) {
               return null;
             }
+            const id = `${item.name}-${generateSafeId(option.value)}-{id}`;
             return (
               <div key={index} className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
                 <input
+                  id={id}
                   type="checkbox"
                   name={`${item.name}{id}[]`}
                   value={option.value}
                   {...(isChecked && {
                     'data-tmp': `{${item.name}:checked#${option.value}}`,
                   })}
-                  id={`input-checkbox-${item.name}-{id}-${option.value}`}
                 />
-                <label htmlFor={`input-checkbox-${item.name}-{id}-${option.value}`}>
+                <label htmlFor={id}>
                   {acmscss && <i className="acms-admin-ico-checkbox" />}
                   {option.label}
                 </label>

--- a/src/components/html/FileInput.jsx
+++ b/src/components/html/FileInput.jsx
@@ -85,7 +85,7 @@ export function FileInput(props) {
           {item.fileNameMethod === 'asis' && (
             <input type="hidden" name={`${item.name}@filename[]`} value="@rawfilename" />
           )}
-          <input type="file" name={`${item.name}[]`} id={item.name} />
+          <input type="file" name={`${item.name}[]`} id={`${item.name}[]`} />
         </>
       )}
 
@@ -143,7 +143,7 @@ export function FileInput(props) {
               <input type="hidden" name={`${item.name}{id}@old[]`} value={`{${item.name}@path}`} />
             </>
           )}
-          <input type="file" name={`${item.name}{id}[]`} id={`${item.name}{id}`} />
+          <input type="file" name={`${item.name}{id}[]`} id={`${item.name}{id}[]`} />
           {!isValue && item.extension && (
             <input type="hidden" name={`${item.name}{id}@extension[]`} value="{extension}" />
           )}

--- a/src/components/html/FileInput.jsx
+++ b/src/components/html/FileInput.jsx
@@ -26,8 +26,8 @@ export function FileInput(props) {
           <input type="hidden" name={`${item.name}@old`} value={`{${item.name}@path}`} />
           <input type="hidden" name={`${item.name}@secret`} value={`{${item.name}@secret}`} />
           <input type="hidden" name={`${item.name}@fileSize`} value={`{${item.name}@fileSize}`} />
-          <label htmlFor={`${item.name}-delete`} className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
-            <input type="checkbox" name={`${item.name}@edit`} value="delete" id={`${item.name}-delete`} />
+          <label className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
+            <input type="checkbox" name={`${item.name}@edit`} value="delete" />
             {acmscss && <i className="acms-admin-ico-checkbox" />}
             削除
           </label>
@@ -35,7 +35,7 @@ export function FileInput(props) {
             <img src={src} width="64" height="64" alt={alt} />
           </a>
           {editMode === 'preview' ? null : `<!-- END ${item.name}@path:veil -->`}
-          <input type="file" name={item.name} />
+          <input type="file" name={item.name} id={item.name} />
           <input type="hidden" name="field[]" value={item.name} />
           <input type="hidden" name={`${item.name}@path`} value={`{${item.name}@path}`} />
           <input type="hidden" name={`${item.name}@fileSize`} value={`{${item.name}@fileSize}`} />
@@ -62,8 +62,8 @@ export function FileInput(props) {
             <>
               {editMode === 'preview' ? null : `<!-- BEGIN_IF [{${item.name}@path}/nem] -->`}
               <div className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
-                <input type="checkbox" name={`${item.name}@edit[]`} value="delete" id={`${item.name}-delete-{i}`} />
-                <label htmlFor={`${item.name}-delete-{i}`}>
+                <label>
+                  <input type="checkbox" name={`${item.name}@edit[]`} value="delete" />
                   {acmscss && <i className="acms-admin-ico-checkbox" />} 削除
                 </label>
               </div>
@@ -85,7 +85,7 @@ export function FileInput(props) {
           {item.fileNameMethod === 'asis' && (
             <input type="hidden" name={`${item.name}@filename[]`} value="@rawfilename" />
           )}
-          <input type="file" name={`${item.name}[]`} />
+          <input type="file" name={`${item.name}[]`} id={item.name} />
         </>
       )}
 
@@ -95,8 +95,8 @@ export function FileInput(props) {
           <input type="hidden" name={`${item.name}{id}@old`} value={`{${item.name}@path}`} />
           <input type="hidden" name={`${item.name}{id}@secret`} value={`{${item.name}@secret}`} />
           <input type="hidden" name={`${item.name}{id}@fileSize`} value={`{${item.name}@fileSize}`} />
-          <label htmlFor={`${item.name}-delete-{id}`} className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
-            <input type="checkbox" name={`${item.name}{id}@edit`} value="delete" id={`${item.name}-delete-{id}`} />
+          <label className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
+            <input type="checkbox" name={`${item.name}{id}@edit`} value="delete" />
             {acmscss && <i className="acms-admin-ico-checkbox" />}
             削除
           </label>
@@ -104,7 +104,7 @@ export function FileInput(props) {
             <img src={src} width="64" height="64" alt={alt} />
           </a>
           {editMode === 'preview' ? null : '<!-- END_IF -->'}
-          <input type="file" name={`${item.name}{id}`} />
+          <input type="file" name={`${item.name}{id}`} id={`${item.name}{id}`} />
           <input type="hidden" name="unit{id}[]" value={`${item.name}{id}`} />
           <input type="hidden" name={`${item.name}{id}@path`} value={`{${item.name}@path}`} />
           <input type="hidden" name={`${item.name}{id}@fileSize`} value={`{${item.name}@fileSize}`} />
@@ -131,13 +131,8 @@ export function FileInput(props) {
             <>
               {editMode === 'preview' ? null : `<!-- BEGIN_IF [{${item.name}@path}/nem] -->`}
               <div className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
-                <input
-                  type="checkbox"
-                  name={`${item.name}{id}@edit[]`}
-                  value="delete"
-                  id={`${item.name}-delete-{id}`}
-                />
-                <label htmlFor={`${item.name}-delete-{id}`}>
+                <label>
+                  <input type="checkbox" name={`${item.name}{id}@edit[]`} value="delete" />
                   {acmscss && <i className="acms-admin-ico-checkbox" />} 削除
                 </label>
               </div>
@@ -148,7 +143,7 @@ export function FileInput(props) {
               <input type="hidden" name={`${item.name}{id}@old[]`} value={`{${item.name}@path}`} />
             </>
           )}
-          <input type="file" name={`${item.name}{id}[]`} />
+          <input type="file" name={`${item.name}{id}[]`} id={`${item.name}{id}`} />
           {!isValue && item.extension && (
             <input type="hidden" name={`${item.name}{id}@extension[]`} value="{extension}" />
           )}

--- a/src/components/html/FileInput.jsx
+++ b/src/components/html/FileInput.jsx
@@ -35,7 +35,7 @@ export function FileInput(props) {
             <img src={src} width="64" height="64" alt={alt} />
           </a>
           {editMode === 'preview' ? null : `<!-- END ${item.name}@path:veil -->`}
-          <input type="file" name={item.name} id={item.name} />
+          <input type="file" name={item.name} />
           <input type="hidden" name="field[]" value={item.name} />
           <input type="hidden" name={`${item.name}@path`} value={`{${item.name}@path}`} />
           <input type="hidden" name={`${item.name}@fileSize`} value={`{${item.name}@fileSize}`} />

--- a/src/components/html/FileInput.jsx
+++ b/src/components/html/FileInput.jsx
@@ -26,11 +26,8 @@ export function FileInput(props) {
           <input type="hidden" name={`${item.name}@old`} value={`{${item.name}@path}`} />
           <input type="hidden" name={`${item.name}@secret`} value={`{${item.name}@secret}`} />
           <input type="hidden" name={`${item.name}@fileSize`} value={`{${item.name}@fileSize}`} />
-          <label
-            htmlFor={`input-checkbox-${item.name}@edit`}
-            className={classnames({ 'acms-admin-form-checkbox': acmscss })}
-          >
-            <input type="checkbox" name={`${item.name}@edit`} value="delete" id={`input-checkbox-${item.name}@edit`} />
+          <label htmlFor={`${item.name}-delete`} className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
+            <input type="checkbox" name={`${item.name}@edit`} value="delete" id={`${item.name}-delete`} />
             {acmscss && <i className="acms-admin-ico-checkbox" />}
             削除
           </label>
@@ -65,13 +62,8 @@ export function FileInput(props) {
             <>
               {editMode === 'preview' ? null : `<!-- BEGIN_IF [{${item.name}@path}/nem] -->`}
               <div className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
-                <input
-                  type="checkbox"
-                  name={`${item.name}@edit[]`}
-                  value="delete"
-                  id={`input-checkbox-${item.name}{i}@edit[]`}
-                />
-                <label htmlFor={`input-checkbox-${item.name}{i}@edit[]`}>
+                <input type="checkbox" name={`${item.name}@edit[]`} value="delete" id={`${item.name}-delete-{i}`} />
+                <label htmlFor={`${item.name}-delete-{i}`}>
                   {acmscss && <i className="acms-admin-ico-checkbox" />} 削除
                 </label>
               </div>
@@ -103,16 +95,8 @@ export function FileInput(props) {
           <input type="hidden" name={`${item.name}{id}@old`} value={`{${item.name}@path}`} />
           <input type="hidden" name={`${item.name}{id}@secret`} value={`{${item.name}@secret}`} />
           <input type="hidden" name={`${item.name}{id}@fileSize`} value={`{${item.name}@fileSize}`} />
-          <label
-            htmlFor={`input-checkbox-${item.name}{id}@edit`}
-            className={classnames({ 'acms-admin-form-checkbox': acmscss })}
-          >
-            <input
-              type="checkbox"
-              name={`${item.name}{id}@edit`}
-              value="delete"
-              id={`input-checkbox-${item.name}{id}@edit`}
-            />
+          <label htmlFor={`${item.name}-delete-{id}`} className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
+            <input type="checkbox" name={`${item.name}{id}@edit`} value="delete" id={`${item.name}-delete-{id}`} />
             {acmscss && <i className="acms-admin-ico-checkbox" />}
             削除
           </label>
@@ -151,9 +135,9 @@ export function FileInput(props) {
                   type="checkbox"
                   name={`${item.name}{id}@edit[]`}
                   value="delete"
-                  id={`input-checkbox-${item.name}{id}@edit[]`}
+                  id={`${item.name}-delete-{id}`}
                 />
-                <label htmlFor={`input-checkbox-${item.name}{id}@edit[]`}>
+                <label htmlFor={`${item.name}-delete-{id}`}>
                   {acmscss && <i className="acms-admin-ico-checkbox" />} 削除
                 </label>
               </div>

--- a/src/components/html/FileInput.jsx
+++ b/src/components/html/FileInput.jsx
@@ -4,7 +4,7 @@ import { useMakerContext } from '../../store/MakerContext';
 import { OptionValidator } from './OptionValidator';
 
 export function FileInput(props) {
-  const { item, id, isValue = true } = props;
+  const { item, isValue = true } = props;
   const {
     preview: { acmscss, editMode, mode },
   } = useMakerContext();
@@ -38,7 +38,7 @@ export function FileInput(props) {
             <img src={src} width="64" height="64" alt={alt} />
           </a>
           {editMode === 'preview' ? null : `<!-- END ${item.name}@path:veil -->`}
-          <input type="file" name={item.name} id={id} />
+          <input type="file" name={item.name} id={item.name} />
           <input type="hidden" name="field[]" value={item.name} />
           <input type="hidden" name={`${item.name}@path`} value={`{${item.name}@path}`} />
           <input type="hidden" name={`${item.name}@fileSize`} value={`{${item.name}@fileSize}`} />

--- a/src/components/html/ImageInput.jsx
+++ b/src/components/html/ImageInput.jsx
@@ -112,7 +112,7 @@ export function ImageInput(props) {
               type="file"
               name={`${item.name}[]`}
               className={classnames({ 'js-img_resize_input': item.resize })}
-              id={item.name}
+              id={`${item.name}[]`}
             />
             <br />
             {item.alt && (
@@ -214,7 +214,7 @@ export function ImageInput(props) {
               type="file"
               name={`${item.name}{id}[]`}
               className={classnames({ 'js-img_resize_input': item.resize })}
-              id={`${item.name}{id}`}
+              id={`${item.name}{id}[]`}
             />
             <br />
             {item.alt && (

--- a/src/components/html/ImageInput.jsx
+++ b/src/components/html/ImageInput.jsx
@@ -35,8 +35,8 @@ export function ImageInput(props) {
           />
           <input type="hidden" name={`${item.name}@old`} value={`{${item.name}@path}`} />
           <div className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
-            <input type="checkbox" name={`${item.name}@edit`} value="delete" id={`input-checkbox-${item.name}@edit`} />
-            <label htmlFor={`input-checkbox-${item.name}@edit`}>
+            <input type="checkbox" name={`${item.name}@edit`} value="delete" id={`${item.name}-delete`} />
+            <label htmlFor={`${item.name}-delete`}>
               {acmscss && <i className="acms-admin-ico-checkbox" />}
               削除
             </label>
@@ -90,15 +90,10 @@ export function ImageInput(props) {
                 />
                 <input type="hidden" name={`${item.name}@old[]`} value={`{${item.name}@path}`} />
                 <label
-                  htmlFor={`input-checkbox-${item.name}@edit[]`}
+                  htmlFor={`${item.name}-delete-{i}`}
                   className={classnames({ 'acms-admin-form-checkbox': acmscss })}
                 >
-                  <input
-                    type="checkbox"
-                    name={`${item.name}@edit[]`}
-                    value="delete"
-                    id={`input-checkbox-${item.name}@edit[]`}
-                  />
+                  <input type="checkbox" name={`${item.name}@edit[]`} value="delete" id={`${item.name}-delete-{i}`} />
                   {acmscss && <i className="acms-admin-ico-checkbox" />}
                   削除
                 </label>
@@ -143,13 +138,8 @@ export function ImageInput(props) {
           />
           <input type="hidden" name={`${item.name}{id}@old`} value={`{${item.name}@path}`} />
           <div className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
-            <input
-              type="checkbox"
-              name={`${item.name}{id}@edit`}
-              value="delete"
-              id={`input-checkbox-${item.name}{id}@edit`}
-            />
-            <label htmlFor={`input-checkbox-${item.name}{id}@edit`}>
+            <input type="checkbox" name={`${item.name}{id}@edit`} value="delete" id={`${item.name}-delete-{id}`} />
+            <label htmlFor={`${item.name}-delete-{id}`}>
               {acmscss && <i className="acms-admin-ico-checkbox" />}
               削除
             </label>
@@ -203,14 +193,14 @@ export function ImageInput(props) {
 
                 <input type="hidden" name={`${item.name}{id}@old[]`} value={`{${item.name}@path}`} />
                 <label
-                  htmlFor={`input-checkbox-${item.name}{id}@edit[]`}
+                  htmlFor={`${item.name}-delete-{id}`}
                   className={classnames({ 'acms-admin-form-checkbox': acmscss })}
                 >
                   <input
                     type="checkbox"
                     name={`${item.name}{id}@edit[]`}
                     value="delete"
-                    id={`input-checkbox-${item.name}{id}@edit[]`}
+                    id={`${item.name}-delete-{id}`}
                   />
                   {acmscss && <i className="acms-admin-ico-checkbox" />}
                   削除

--- a/src/components/html/ImageInput.jsx
+++ b/src/components/html/ImageInput.jsx
@@ -51,7 +51,6 @@ export function ImageInput(props) {
           {editMode === 'preview' ? null : '<!-- END_IF -->'}
           <input
             type="file"
-            id={item.name}
             name={item.name}
             size="20"
             className={classnames({ 'js-img_resize_input': item.resize })}

--- a/src/components/html/ImageInput.jsx
+++ b/src/components/html/ImageInput.jsx
@@ -4,7 +4,7 @@ import { useMakerContext } from '../../store/MakerContext';
 import { OptionValidator } from './OptionValidator';
 
 export function ImageInput(props) {
-  const { item, id, isAttribute = true } = props;
+  const { item, isAttribute = true } = props;
   const {
     preview: { acmscss, editMode, mode },
   } = useMakerContext();
@@ -51,7 +51,7 @@ export function ImageInput(props) {
           {editMode === 'preview' ? null : '<!-- END_IF -->'}
           <input
             type="file"
-            id={id}
+            id={item.name}
             name={item.name}
             size="20"
             className={classnames({ 'js-img_resize_input': item.resize })}

--- a/src/components/html/ImageInput.jsx
+++ b/src/components/html/ImageInput.jsx
@@ -35,8 +35,8 @@ export function ImageInput(props) {
           />
           <input type="hidden" name={`${item.name}@old`} value={`{${item.name}@path}`} />
           <div className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
-            <input type="checkbox" name={`${item.name}@edit`} value="delete" id={`${item.name}-delete`} />
-            <label htmlFor={`${item.name}-delete`}>
+            <label>
+              <input type="checkbox" name={`${item.name}@edit`} value="delete" />
               {acmscss && <i className="acms-admin-ico-checkbox" />}
               削除
             </label>
@@ -54,6 +54,7 @@ export function ImageInput(props) {
             name={item.name}
             size="20"
             className={classnames({ 'js-img_resize_input': item.resize })}
+            id={item.name}
           />
           <br />
           {item.alt && (
@@ -88,11 +89,8 @@ export function ImageInput(props) {
                   alt={`{${item.name}@alt}`}
                 />
                 <input type="hidden" name={`${item.name}@old[]`} value={`{${item.name}@path}`} />
-                <label
-                  htmlFor={`${item.name}-delete-{i}`}
-                  className={classnames({ 'acms-admin-form-checkbox': acmscss })}
-                >
-                  <input type="checkbox" name={`${item.name}@edit[]`} value="delete" id={`${item.name}-delete-{i}`} />
+                <label className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
+                  <input type="checkbox" name={`${item.name}@edit[]`} value="delete" />
                   {acmscss && <i className="acms-admin-ico-checkbox" />}
                   削除
                 </label>
@@ -110,7 +108,12 @@ export function ImageInput(props) {
             )}
             {!isAttribute && <img src="" alt="" style={hiddenStyle} className="js-img_resize_preview" />}
 
-            <input type="file" name={`${item.name}[]`} className={classnames({ 'js-img_resize_input': item.resize })} />
+            <input
+              type="file"
+              name={`${item.name}[]`}
+              className={classnames({ 'js-img_resize_input': item.resize })}
+              id={item.name}
+            />
             <br />
             {item.alt && (
               <>
@@ -137,8 +140,8 @@ export function ImageInput(props) {
           />
           <input type="hidden" name={`${item.name}{id}@old`} value={`{${item.name}@path}`} />
           <div className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
-            <input type="checkbox" name={`${item.name}{id}@edit`} value="delete" id={`${item.name}-delete-{id}`} />
-            <label htmlFor={`${item.name}-delete-{id}`}>
+            <label>
+              <input type="checkbox" name={`${item.name}{id}@edit`} value="delete" />
               {acmscss && <i className="acms-admin-ico-checkbox" />}
               削除
             </label>
@@ -156,6 +159,7 @@ export function ImageInput(props) {
             name={`${item.name}{id}`}
             size="20"
             className={classnames({ 'js-img_resize_input': item.resize })}
+            id={`${item.name}{id}`}
           />
           <br />
           {item.alt && (
@@ -191,16 +195,8 @@ export function ImageInput(props) {
                 </div>
 
                 <input type="hidden" name={`${item.name}{id}@old[]`} value={`{${item.name}@path}`} />
-                <label
-                  htmlFor={`${item.name}-delete-{id}`}
-                  className={classnames({ 'acms-admin-form-checkbox': acmscss })}
-                >
-                  <input
-                    type="checkbox"
-                    name={`${item.name}{id}@edit[]`}
-                    value="delete"
-                    id={`${item.name}-delete-{id}`}
-                  />
+                <label className={classnames({ 'acms-admin-form-checkbox': acmscss })}>
+                  <input type="checkbox" name={`${item.name}{id}@edit[]`} value="delete" />
                   {acmscss && <i className="acms-admin-ico-checkbox" />}
                   削除
                 </label>
@@ -218,6 +214,7 @@ export function ImageInput(props) {
               type="file"
               name={`${item.name}{id}[]`}
               className={classnames({ 'js-img_resize_input': item.resize })}
+              id={`${item.name}{id}`}
             />
             <br />
             {item.alt && (

--- a/src/components/html/Media.jsx
+++ b/src/components/html/Media.jsx
@@ -27,7 +27,6 @@ export function Media(props) {
                     src={`{${item.name}@thumbnail}`}
                     className={classnames('js-preview', { 'acms-admin-img-responsive': acmscss })}
                     alt=""
-                    id={`${item.name}-preview`}
                     {...(item.mediaType === 'file' && {
                       style: {
                         width: '64px',
@@ -50,7 +49,6 @@ export function Media(props) {
                     : { style: { display: 'none' } })}
                   alt=""
                   className={classnames('js-preview', { 'acms-admin-img-responsive': acmscss })}
-                  id={`${item.name}-preview`}
                 />
                 {'<!-- END_IF -->'}
                 <p className="js-text acms-admin-text-danger" style={{ display: 'none' }}>
@@ -112,7 +110,6 @@ export function Media(props) {
           <input
             type="hidden"
             name={item.name}
-            id={item.name}
             value={editMode === 'preview' ? '' : `{${item.name}}`}
             className="js-value"
           />

--- a/src/components/html/Media.jsx
+++ b/src/components/html/Media.jsx
@@ -112,7 +112,7 @@ export function Media(props) {
           <input
             type="hidden"
             name={item.name}
-            id={id}
+            id={item.name}
             value={editMode === 'preview' ? '' : `{${item.name}}`}
             className="js-value"
           />

--- a/src/components/html/Media.jsx
+++ b/src/components/html/Media.jsx
@@ -4,7 +4,7 @@ import { useMakerContext } from '../../store/MakerContext';
 import { OptionValidator } from './OptionValidator';
 
 export function Media(props) {
-  const { item, id, isValue = true } = props;
+  const { item, isValue = true } = props;
   const {
     preview: { acmscss, editMode, mode },
   } = useMakerContext();

--- a/src/components/html/RadioButton.jsx
+++ b/src/components/html/RadioButton.jsx
@@ -48,7 +48,7 @@ export function RadioButton(props) {
             if (!option.label) {
               return null;
             }
-            const id = `${item.name}-${generateSafeId(option.value)}`;
+            const id = `${item.name}-${generateSafeId(option.value)}[]`;
             return (
               <div key={index} className={classnames({ 'acms-admin-form-radio': acmscss })}>
                 <input
@@ -105,7 +105,7 @@ export function RadioButton(props) {
             if (!option.label) {
               return null;
             }
-            const id = `${item.name}-${generateSafeId(option.value)}-{id}`;
+            const id = `${item.name}-${generateSafeId(option.value)}-{id}[]`;
             return (
               <div key={index} className={classnames({ 'acms-admin-form-radio': acmscss })}>
                 <input

--- a/src/components/html/RadioButton.jsx
+++ b/src/components/html/RadioButton.jsx
@@ -3,6 +3,7 @@ import classnames from 'classnames';
 import { useMakerContext } from '../../store/MakerContext';
 import { OptionValidator } from './OptionValidator';
 import { OptionNoSearch } from './OptionNoSearch';
+import { generateSafeId } from '../../utils';
 
 export function RadioButton(props) {
   const { item, isChecked = true } = props;

--- a/src/components/html/RadioButton.jsx
+++ b/src/components/html/RadioButton.jsx
@@ -18,6 +18,7 @@ export function RadioButton(props) {
             if (!option.label) {
               return null;
             }
+            const id = `${item.name}-${generateSafeId(option.value)}`;
             return (
               <div key={index} className={classnames({ 'acms-admin-form-radio': acmscss })}>
                 <input
@@ -25,9 +26,9 @@ export function RadioButton(props) {
                   name={item.name}
                   value={option.value}
                   data-tmp={`{${item.name}:checked#${option.value}}`}
-                  id={`input-radio-${item.name}-${option.value}`}
+                  id={id}
                 />
-                <label htmlFor={`input-radio-${item.name}-${option.value}`}>
+                <label htmlFor={id}>
                   <i className="acms-admin-ico-radio" />
                   {option.label}
                 </label>
@@ -46,6 +47,7 @@ export function RadioButton(props) {
             if (!option.label) {
               return null;
             }
+            const id = `${item.name}-${generateSafeId(option.value)}`;
             return (
               <div key={index} className={classnames({ 'acms-admin-form-radio': acmscss })}>
                 <input
@@ -55,9 +57,9 @@ export function RadioButton(props) {
                   {...(isChecked && {
                     'data-tmp': `{${item.name}:checked#${option.value}}`,
                   })}
-                  id={`input-radio-${item.name}-${option.value}`}
+                  id={id}
                 />
-                <label htmlFor={`input-radio-${item.name}-${option.value}`}>
+                <label htmlFor={id}>
                   {acmscss && <i className="acms-admin-ico-radio" />}
                   {option.label}
                 </label>
@@ -73,6 +75,7 @@ export function RadioButton(props) {
             if (!option.label) {
               return null;
             }
+            const id = `${item.name}-${generateSafeId(option.value)}-{id}`;
             return (
               <div key={index} className={classnames({ 'acms-admin-form-radio': acmscss })}>
                 <input
@@ -80,9 +83,9 @@ export function RadioButton(props) {
                   name={`${item.name}{id}`}
                   value={option.value}
                   data-tmp={`{${item.name}:checked#${option.value}}`}
-                  id={`input-radio-${item.name}-${option.value}-{id}`}
+                  id={id}
                 />
-                <label htmlFor={`input-radio-${item.name}-${option.value}-{id}`}>
+                <label htmlFor={id}>
                   <i className="acms-admin-ico-radio" />
                   {option.label}
                 </label>
@@ -101,6 +104,7 @@ export function RadioButton(props) {
             if (!option.label) {
               return null;
             }
+            const id = `${item.name}-${generateSafeId(option.value)}-{id}`;
             return (
               <div key={index} className={classnames({ 'acms-admin-form-radio': acmscss })}>
                 <input
@@ -110,9 +114,9 @@ export function RadioButton(props) {
                   {...(isChecked && {
                     'data-tmp': `{${item.name}:checked#${option.value}}`,
                   })}
-                  id={`input-radio-${item.name}-{id}-${option.value}`}
+                  id={id}
                 />
-                <label htmlFor={`input-radio-${item.name}-{id}-${option.value}`}>
+                <label htmlFor={id}>
                   {acmscss && <i className="acms-admin-ico-radio" />}
                   {option.label}
                 </label>

--- a/src/components/html/RichEditor.jsx
+++ b/src/components/html/RichEditor.jsx
@@ -34,7 +34,7 @@ export function RichEditor(props) {
           >
             <div className="js-smartblock-edit" />
             <input className="js-smartblock-body" type="hidden" name={item.name} value={`{${item.name}@html}`} />
-            <input id={item.name} type="hidden" name="field[]" value={item.name} />
+            <input type="hidden" name="field[]" value={item.name} />
             <input type="hidden" name={`${item.name}:extension`} value="rich-editor" />
           </div>
         </ConditionalWrap>
@@ -63,7 +63,6 @@ export function RichEditor(props) {
             {isValue ? (
               <>
                 <input
-                  id={item.name}
                   className="js-smartblock-body"
                   type="hidden"
                   name={`${item.name}[]`}
@@ -72,7 +71,7 @@ export function RichEditor(props) {
                 <input type="hidden" name={`${item.name}:extension`} value="rich-editor" />
               </>
             ) : (
-              <input id={item.name} className="js-smartblock-body" type="hidden" name={`${item.name}[]`} value="" />
+              <input className="js-smartblock-body" type="hidden" name={`${item.name}[]`} value="" />
             )}
           </div>
         </ConditionalWrap>

--- a/src/components/html/RichEditor.jsx
+++ b/src/components/html/RichEditor.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useMakerContext } from '../../store/MakerContext';
 
 export function RichEditor(props) {
-  const { item, id = '', isValue = true } = props;
+  const { item, isValue = true } = props;
   const {
     preview: { mode },
   } = useMakerContext();
@@ -34,7 +34,7 @@ export function RichEditor(props) {
           >
             <div className="js-smartblock-edit" />
             <input className="js-smartblock-body" type="hidden" name={item.name} value={`{${item.name}@html}`} />
-            <input id={id} type="hidden" name="field[]" value={item.name} />
+            <input id={item.name} type="hidden" name="field[]" value={item.name} />
             <input type="hidden" name={`${item.name}:extension`} value="rich-editor" />
           </div>
         </ConditionalWrap>
@@ -63,7 +63,7 @@ export function RichEditor(props) {
             {isValue ? (
               <>
                 <input
-                  id={id}
+                  id={item.name}
                   className="js-smartblock-body"
                   type="hidden"
                   name={`${item.name}[]`}
@@ -72,7 +72,7 @@ export function RichEditor(props) {
                 <input type="hidden" name={`${item.name}:extension`} value="rich-editor" />
               </>
             ) : (
-              <input id={id} className="js-smartblock-body" type="hidden" name={`${item.name}[]`} value="" />
+              <input id={item.name} className="js-smartblock-body" type="hidden" name={`${item.name}[]`} value="" />
             )}
           </div>
         </ConditionalWrap>

--- a/src/components/html/Selectbox.jsx
+++ b/src/components/html/Selectbox.jsx
@@ -5,7 +5,7 @@ import { OptionValidator } from './OptionValidator';
 import { OptionNoSearch } from './OptionNoSearch';
 
 export function Selectbox(props) {
-  const { item, id = '', isSelected = true } = props;
+  const { item, isSelected = true } = props;
   const {
     preview: { mode, acmscss },
   } = useMakerContext();
@@ -14,7 +14,7 @@ export function Selectbox(props) {
     <>
       {mode === 'customfield' && (
         <>
-          <select id={id} name={item.name} className={classnames({ 'acms-admin-form-width-full': acmscss })}>
+          <select id={item.name} name={item.name} className={classnames({ 'acms-admin-form-width-full': acmscss })}>
             <option value="" />
             {item.option.map((option, index) => {
               if (!option.label) {
@@ -36,7 +36,11 @@ export function Selectbox(props) {
 
       {mode === 'fieldgroup' && (
         <>
-          <select id={id} name={`${item.name}[]`} className={classnames({ 'acms-admin-form-width-full': acmscss })}>
+          <select
+            id={item.name}
+            name={`${item.name}[]`}
+            className={classnames({ 'acms-admin-form-width-full': acmscss })}
+          >
             <option value="" />
             {item.option.map((option, index) => {
               if (!option.label) {
@@ -60,7 +64,11 @@ export function Selectbox(props) {
 
       {mode === 'customunit' && (
         <>
-          <select id={id} name={`${item.name}{id}`} className={classnames({ 'acms-admin-form-width-full': acmscss })}>
+          <select
+            id={item.name}
+            name={`${item.name}{id}`}
+            className={classnames({ 'acms-admin-form-width-full': acmscss })}
+          >
             <option value="" />
             {item.option.map((option, index) => {
               if (!option.label) {

--- a/src/components/html/Selectbox.jsx
+++ b/src/components/html/Selectbox.jsx
@@ -65,7 +65,7 @@ export function Selectbox(props) {
       {mode === 'customunit' && (
         <>
           <select
-            id={item.name}
+            id={`${item.name}{id}`}
             name={`${item.name}{id}`}
             className={classnames({ 'acms-admin-form-width-full': acmscss })}
           >
@@ -90,7 +90,7 @@ export function Selectbox(props) {
       {mode === 'unitgroup' && (
         <>
           <select
-            id={item.name}
+            id={`${item.name}{id}`}
             name={`${item.name}{id}[]`}
             className={classnames({ 'acms-admin-form-width-full': acmscss })}
           >

--- a/src/components/html/Selectbox.jsx
+++ b/src/components/html/Selectbox.jsx
@@ -89,7 +89,11 @@ export function Selectbox(props) {
 
       {mode === 'unitgroup' && (
         <>
-          <select name={`${item.name}{id}[]`} className={classnames({ 'acms-admin-form-width-full': acmscss })}>
+          <select
+            id={item.name}
+            name={`${item.name}{id}[]`}
+            className={classnames({ 'acms-admin-form-width-full': acmscss })}
+          >
             <option value="" />
             {item.option.map((option, index) => {
               if (!option.label) {

--- a/src/components/html/Selectbox.jsx
+++ b/src/components/html/Selectbox.jsx
@@ -37,7 +37,7 @@ export function Selectbox(props) {
       {mode === 'fieldgroup' && (
         <>
           <select
-            id={item.name}
+            id={`${item.name}[]`}
             name={`${item.name}[]`}
             className={classnames({ 'acms-admin-form-width-full': acmscss })}
           >
@@ -90,7 +90,7 @@ export function Selectbox(props) {
       {mode === 'unitgroup' && (
         <>
           <select
-            id={`${item.name}{id}`}
+            id={`${item.name}{id}[]`}
             name={`${item.name}{id}[]`}
             className={classnames({ 'acms-admin-form-width-full': acmscss })}
           >

--- a/src/components/html/Table.jsx
+++ b/src/components/html/Table.jsx
@@ -51,7 +51,6 @@ export function Table(props) {
               </table>
               {editMode === 'preview' ? null : '<!-- END_IF -->'}
               <input
-                id={item.name}
                 type="hidden"
                 className="js-editable-table-dest"
                 {...(isValue && {
@@ -82,7 +81,6 @@ export function Table(props) {
             </table>
             {editMode === 'preview' ? null : '<!-- END_IF -->'}
             <input
-              id={item.name}
               type="hidden"
               className="js-editable-table-dest"
               value={`{${item.name}}`}
@@ -112,7 +110,6 @@ export function Table(props) {
               </table>
               {editMode === 'preview' ? null : '<!-- END_IF -->'}
               <input
-                id={item.name}
                 type="hidden"
                 className="js-editable-table-dest"
                 {...(isValue && {

--- a/src/components/html/Table.jsx
+++ b/src/components/html/Table.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useMakerContext } from '../../store/MakerContext';
 
 export function Table(props) {
-  const { item, id = '', isValue = true } = props;
+  const { item, isValue = true } = props;
   const {
     preview: { mode, editMode },
   } = useMakerContext();
@@ -27,7 +27,7 @@ export function Table(props) {
             </table>
             {editMode === 'preview' ? null : '<!-- END_IF -->'}
             <input type="hidden" className="js-editable-table-dest" value={`{${item.name}}`} name={item.name} />
-            <input id={id} type="hidden" name="field[]" value={item.name} />
+            <input id={item.name} type="hidden" name="field[]" value={item.name} />
           </div>
         </div>
       )}
@@ -51,7 +51,7 @@ export function Table(props) {
               </table>
               {editMode === 'preview' ? null : '<!-- END_IF -->'}
               <input
-                id={id}
+                id={item.name}
                 type="hidden"
                 className="js-editable-table-dest"
                 {...(isValue && {
@@ -82,7 +82,7 @@ export function Table(props) {
             </table>
             {editMode === 'preview' ? null : '<!-- END_IF -->'}
             <input
-              id={id}
+              id={item.name}
               type="hidden"
               className="js-editable-table-dest"
               value={`{${item.name}}`}
@@ -112,7 +112,7 @@ export function Table(props) {
               </table>
               {editMode === 'preview' ? null : '<!-- END_IF -->'}
               <input
-                id={id}
+                id={item.name}
                 type="hidden"
                 className="js-editable-table-dest"
                 {...(isValue && {

--- a/src/components/html/TextInput.jsx
+++ b/src/components/html/TextInput.jsx
@@ -32,7 +32,7 @@ export function TextInput(props) {
       {mode === 'fieldgroup' && (
         <>
           <input
-            id={item.name}
+            id={`${item.name}[]`}
             type={item.type}
             name={`${item.name}[]`}
             {...(isValue && {
@@ -63,7 +63,7 @@ export function TextInput(props) {
       {mode === 'unitgroup' && (
         <>
           <input
-            id={`${item.name}{id}`}
+            id={`${item.name}{id}[]`}
             type={item.type}
             name={`${item.name}{id}[]`}
             {...(isValue && {

--- a/src/components/html/TextInput.jsx
+++ b/src/components/html/TextInput.jsx
@@ -47,7 +47,7 @@ export function TextInput(props) {
       {mode === 'customunit' && (
         <>
           <input
-            id={item.name}
+            id={`${item.name}{id}`}
             type={item.type}
             name={`${item.name}{id}`}
             defaultValue={`{${item.name}}`}
@@ -63,7 +63,7 @@ export function TextInput(props) {
       {mode === 'unitgroup' && (
         <>
           <input
-            id={item.name}
+            id={`${item.name}{id}`}
             type={item.type}
             name={`${item.name}{id}[]`}
             {...(isValue && {

--- a/src/components/html/TextInput.jsx
+++ b/src/components/html/TextInput.jsx
@@ -5,7 +5,7 @@ import { OptionValidator } from './OptionValidator';
 import { OptionNoSearch } from './OptionNoSearch';
 
 export function TextInput(props) {
-  const { item, id = '', isValue = true } = props;
+  const { item, isValue = true } = props;
   const {
     preview: { mode, jsValidator, acmscss },
   } = useMakerContext();
@@ -15,7 +15,7 @@ export function TextInput(props) {
       {mode === 'customfield' && (
         <>
           <input
-            id={id}
+            id={item.name}
             type={item.type}
             name={item.name}
             defaultValue={`{${item.name}}`}
@@ -32,6 +32,7 @@ export function TextInput(props) {
       {mode === 'fieldgroup' && (
         <>
           <input
+            id={item.name}
             type={item.type}
             name={`${item.name}[]`}
             {...(isValue && {
@@ -46,6 +47,7 @@ export function TextInput(props) {
       {mode === 'customunit' && (
         <>
           <input
+            id={item.name}
             type={item.type}
             name={`${item.name}{id}`}
             defaultValue={`{${item.name}}`}
@@ -61,6 +63,7 @@ export function TextInput(props) {
       {mode === 'unitgroup' && (
         <>
           <input
+            id={item.name}
             type={item.type}
             name={`${item.name}{id}[]`}
             {...(isValue && {

--- a/src/components/html/Textarea.jsx
+++ b/src/components/html/Textarea.jsx
@@ -5,7 +5,7 @@ import { OptionValidator } from './OptionValidator';
 import { OptionNoSearch } from './OptionNoSearch';
 
 export function Textarea(props) {
-  const { item, id = '', isValue = true } = props;
+  const { item, isValue = true } = props;
   const {
     preview: { mode, jsValidator, acmscss },
   } = useMakerContext();
@@ -22,7 +22,7 @@ export function Textarea(props) {
       {mode === 'customfield' && (
         <>
           <textarea
-            id={id}
+            id={item.name}
             name={item.name}
             className={classname}
             defaultValue={value}
@@ -39,7 +39,7 @@ export function Textarea(props) {
       {mode === 'fieldgroup' && (
         <>
           <textarea
-            id={id}
+            id={item.name}
             name={`${item.name}[]`}
             className={classname}
             defaultValue={value}
@@ -52,7 +52,7 @@ export function Textarea(props) {
       {mode === 'customunit' && (
         <>
           <textarea
-            id={id}
+            id={item.name}
             name={`${item.name}{id}`}
             className={classname}
             defaultValue={value}
@@ -68,7 +68,7 @@ export function Textarea(props) {
       {mode === 'unitgroup' && (
         <>
           <textarea
-            id={id}
+            id={item.name}
             name={`${item.name}{id}[]`}
             className={classname}
             defaultValue={value}

--- a/src/components/html/Textarea.jsx
+++ b/src/components/html/Textarea.jsx
@@ -39,7 +39,7 @@ export function Textarea(props) {
       {mode === 'fieldgroup' && (
         <>
           <textarea
-            id={item.name}
+            id={`${item.name}[]`}
             name={`${item.name}[]`}
             className={classname}
             defaultValue={value}
@@ -68,7 +68,7 @@ export function Textarea(props) {
       {mode === 'unitgroup' && (
         <>
           <textarea
-            id={`${item.name}{id}`}
+            id={`${item.name}{id}[]`}
             name={`${item.name}{id}[]`}
             className={classname}
             defaultValue={value}

--- a/src/components/html/Textarea.jsx
+++ b/src/components/html/Textarea.jsx
@@ -52,7 +52,7 @@ export function Textarea(props) {
       {mode === 'customunit' && (
         <>
           <textarea
-            id={item.name}
+            id={`${item.name}{id}`}
             name={`${item.name}{id}`}
             className={classname}
             defaultValue={value}
@@ -68,7 +68,7 @@ export function Textarea(props) {
       {mode === 'unitgroup' && (
         <>
           <textarea
-            id={item.name}
+            id={`${item.name}{id}`}
             name={`${item.name}{id}[]`}
             className={classname}
             defaultValue={value}

--- a/src/components/layouts/GroupSection.jsx
+++ b/src/components/layouts/GroupSection.jsx
@@ -135,10 +135,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                 case 'media': {
                   return (
                     <>
-                      <label
-                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
-                      >
+                      <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -150,10 +147,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                 case 'image': {
                   return (
                     <>
-                      <label
-                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
-                      >
+                      <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -165,10 +159,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                 case 'file': {
                   return (
                     <>
-                      <label
-                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}`}
-                      >
+                      <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -180,10 +171,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                 case 'richEditor': {
                   return (
                     <>
-                      <label
-                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
-                      >
+                      <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -365,7 +353,6 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -380,7 +367,6 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -395,7 +381,6 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -410,7 +395,6 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>

--- a/src/components/layouts/GroupSection.jsx
+++ b/src/components/layouts/GroupSection.jsx
@@ -67,12 +67,12 @@ export const GroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}`}
+                        htmlFor={item.name}
                       >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <TextInput item={item} id={`${item.name}`} isValue={false} />
+                        <TextInput item={item} isValue={false} />
                       </div>
                     </>
                   );
@@ -83,12 +83,12 @@ export const GroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}${index}`}
+                        htmlFor={item.name}
                       >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <Textarea item={item} id={`template-${item.name}${index}`} isValue={false} />
+                        <Textarea item={item} isValue={false} />
                       </div>
                     </>
                   );
@@ -100,7 +100,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                         <Heading item={item} />
                       </legend>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <Checkbox item={item} id={`template-${item.name}${index}`} isChecked={false} />
+                        <Checkbox item={item} isChecked={false} />
                       </div>
                     </fieldset>
                   );
@@ -110,12 +110,12 @@ export const GroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}${index}`}
+                        htmlFor={item.name}
                       >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <Selectbox item={item} id={`${item.name}${index}`} isSelected={false} />
+                        <Selectbox item={item} isSelected={false} />
                       </div>
                     </>
                   );
@@ -123,14 +123,11 @@ export const GroupSection = forwardRef((_props, ref) => {
                 case 'radioButton': {
                   return (
                     <fieldset key={index} className={classnames({ 'acms-admin-contents': acmscss })}>
-                      <legend
-                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        id={`${item.name}${index}`}
-                      >
+                      <legend className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                         <Heading item={item} />
                       </legend>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <RadioButton item={item} id={`${item.name}${index}`} isChecked={false} />
+                        <RadioButton item={item} isChecked={false} />
                       </div>
                     </fieldset>
                   );
@@ -140,12 +137,12 @@ export const GroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}${index}`}
+                        htmlFor={item.name}
                       >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <Media item={item} id={`${item.name}${index}`} isValue={false} />
+                        <Media item={item} isValue={false} />
                       </div>
                     </>
                   );
@@ -155,12 +152,12 @@ export const GroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}${index}`}
+                        htmlFor={item.name}
                       >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <ImageInput item={item} id={`${item.name}${index}`} isAttribute={false} />
+                        <ImageInput item={item} isAttribute={false} />
                       </div>
                     </>
                   );
@@ -175,7 +172,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <FileInput item={item} id={`${item.name}`} isValue={false} />
+                        <FileInput item={item} isValue={false} />
                       </div>
                     </>
                   );
@@ -185,12 +182,12 @@ export const GroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}${index}`}
+                        htmlFor={item.name}
                       >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <RichEditor item={item} id={`${item.name}${index}`} isValue={false} />
+                        <RichEditor item={item} isValue={false} />
                       </div>
                     </>
                   );
@@ -294,12 +291,12 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}`}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <TextInput item={item} id={`${item.name}`} />
+                                          <TextInput item={item} />
                                         </div>
                                       </>
                                     );
@@ -310,12 +307,12 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}${index}`}
+                                          htmlFor={item.name}
                                         >
-                                          <Heading item={item} id={`${item.name}${index}`} />
+                                          <Heading item={item} />
                                         </label>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <Textarea item={item} id={`${item.name}${index}`} />
+                                          <Textarea item={item} />
                                         </div>
                                       </>
                                     );
@@ -326,10 +323,10 @@ export const GroupSection = forwardRef((_props, ref) => {
                                         <legend
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
                                         >
-                                          <Heading item={item} id={`${item.name}${index}`} />
+                                          <Heading item={item} />
                                         </legend>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <Checkbox item={item} id={`${item.name}${index}`} />
+                                          <Checkbox item={item} />
                                         </div>
                                       </fieldset>
                                     );
@@ -339,12 +336,12 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}${index}`}
+                                          htmlFor={item.name}
                                         >
-                                          <Heading item={item} id={`${item.name}${index}`} />
+                                          <Heading item={item} />
                                         </label>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <Selectbox item={item} id={`${item.name}${index}`} />
+                                          <Selectbox item={item} />
                                         </div>
                                       </>
                                     );
@@ -354,12 +351,11 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <fieldset className={classnames({ 'acms-admin-contents': acmscss })}>
                                         <legend
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          id={`${item.name}${index}`}
                                         >
                                           <Heading item={item} />
                                         </legend>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <RadioButton item={item} id={`${item.name}${index}`} />
+                                          <RadioButton item={item} />
                                         </div>
                                       </fieldset>
                                     );
@@ -369,12 +365,12 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}${index}`}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <Media item={item} id={`${item.name}${index}`} />
+                                          <Media item={item} />
                                         </div>
                                       </>
                                     );
@@ -384,12 +380,12 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}${index}`}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <ImageInput item={item} id={`${item.name}${index}`} />
+                                          <ImageInput item={item} />
                                         </div>
                                       </>
                                     );
@@ -399,12 +395,12 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}${index}`}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <FileInput item={item} id={`${item.name}${index}`} />
+                                          <FileInput item={item} />
                                         </div>
                                       </>
                                     );
@@ -414,12 +410,12 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}${index}`}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <RichEditor item={item} id={`${item.name}${index}`} />
+                                          <RichEditor item={item} />
                                         </div>
                                       </>
                                     );
@@ -429,12 +425,12 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}${index}`}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <Table item={item} id={`${item.name}${index}`} />
+                                          <Table item={item} />
                                         </div>
                                       </>
                                     );

--- a/src/components/layouts/GroupSection.jsx
+++ b/src/components/layouts/GroupSection.jsx
@@ -67,7 +67,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
+                        htmlFor={`${item.name}[]`}
                       >
                         <Heading item={item} />
                       </label>
@@ -83,7 +83,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
+                        htmlFor={`${item.name}[]`}
                       >
                         <Heading item={item} />
                       </label>
@@ -149,7 +149,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
+                        htmlFor={`${item.name}[]`}
                       >
                         <Heading item={item} />
                       </label>
@@ -164,7 +164,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
+                        htmlFor={`${item.name}[]`}
                       >
                         <Heading item={item} />
                       </label>
@@ -282,7 +282,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
+                                          htmlFor={`${item.name}[]`}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -298,7 +298,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
+                                          htmlFor={`${item.name}[]`}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -327,7 +327,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
+                                          htmlFor={`${item.name}[]`}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -370,7 +370,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
+                                          htmlFor={`${item.name}[]`}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -385,7 +385,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
+                                          htmlFor={`${item.name}[]`}
                                         >
                                           <Heading item={item} />
                                         </label>

--- a/src/components/layouts/GroupSection.jsx
+++ b/src/components/layouts/GroupSection.jsx
@@ -147,7 +147,10 @@ export const GroupSection = forwardRef((_props, ref) => {
                 case 'image': {
                   return (
                     <>
-                      <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
+                      <label
+                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
+                        htmlFor={item.name}
+                      >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -159,7 +162,10 @@ export const GroupSection = forwardRef((_props, ref) => {
                 case 'file': {
                   return (
                     <>
-                      <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
+                      <label
+                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
+                        htmlFor={item.name}
+                      >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -367,6 +373,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -381,6 +388,7 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>

--- a/src/components/layouts/GroupSection.jsx
+++ b/src/components/layouts/GroupSection.jsx
@@ -189,14 +189,11 @@ export const GroupSection = forwardRef((_props, ref) => {
                 case 'table': {
                   return (
                     <>
-                      <label
-                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}${index}`}
-                      >
+                      <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <Table item={item} id={`${item.name}${index}`} isValue={false} />
+                        <Table item={item} isValue={false} />
                       </div>
                     </>
                   );
@@ -417,7 +414,6 @@ export const GroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>

--- a/src/components/layouts/GroupTableLayout.jsx
+++ b/src/components/layouts/GroupTableLayout.jsx
@@ -78,7 +78,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                           {acmscss && <i className="acms-admin-icon-sort" />}
                         </td>
                         <>
-                          {fieldgroup.items.map((item, index) => {
+                          {fieldgroup.items.map((item) => {
                             switch (item.type) {
                               case 'text':
                               case 'tel':

--- a/src/components/layouts/GroupTableLayout.jsx
+++ b/src/components/layouts/GroupTableLayout.jsx
@@ -88,7 +88,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                 return (
                                   <WrapTable title={item.title}>
                                     <td>
-                                      <TextInput item={item} id={`${item.name}${index}`} />
+                                      <TextInput item={item} />
                                     </td>
                                   </WrapTable>
                                 );
@@ -98,7 +98,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                 return (
                                   <WrapTable title={item.title}>
                                     <td>
-                                      <Textarea item={item} id={`${item.name}${index}`} />
+                                      <Textarea item={item} />
                                     </td>
                                   </WrapTable>
                                 );
@@ -107,7 +107,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                 return (
                                   <WrapTable title={item.title}>
                                     <td>
-                                      <Checkbox item={item} id={`${item.name}${index}`} />
+                                      <Checkbox item={item} />
                                     </td>
                                   </WrapTable>
                                 );
@@ -116,7 +116,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                 return (
                                   <WrapTable title={item.title}>
                                     <td>
-                                      <Selectbox item={item} id={`${item.name}${index}`} />
+                                      <Selectbox item={item} />
                                     </td>
                                   </WrapTable>
                                 );
@@ -125,7 +125,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                 return (
                                   <WrapTable title={item.title}>
                                     <td>
-                                      <RadioButton item={item} id={`${item.name}${index}`} />
+                                      <RadioButton item={item} />
                                     </td>
                                   </WrapTable>
                                 );
@@ -134,7 +134,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                 return (
                                   <WrapTable title={item.title}>
                                     <td>
-                                      <Media item={item} id={`${item.name}${index}`} />
+                                      <Media item={item} />
                                     </td>
                                   </WrapTable>
                                 );
@@ -143,7 +143,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                 return (
                                   <WrapTable title={item.title}>
                                     <td>
-                                      <ImageInput item={item} id={`${item.name}${index}`} />
+                                      <ImageInput item={item} />
                                     </td>
                                   </WrapTable>
                                 );
@@ -165,7 +165,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                           </div>
                                         )}
                                       >
-                                        <RichEditor item={item} id={`${item.name}${index}`} />
+                                        <RichEditor item={item} />
                                       </ConditionalWrap>
                                     </td>
                                   </WrapTable>
@@ -175,7 +175,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                 return (
                                   <WrapTable title={item.title}>
                                     <td>
-                                      <Table item={item} id={`${item.name}${index}`} />
+                                      <Table item={item} />
                                     </td>
                                   </WrapTable>
                                 );
@@ -218,7 +218,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                     return (
                                       <WrapTable title={item.title}>
                                         <td>
-                                          <TextInput item={item} id={`${item.name}${index}`} isValue={false} />
+                                          <TextInput item={item} isValue={false} />
                                         </td>
                                       </WrapTable>
                                     );
@@ -228,7 +228,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                     return (
                                       <WrapTable title={item.title}>
                                         <td>
-                                          <Textarea item={item} id={`${item.name}${index}`} isValue={false} />
+                                          <Textarea item={item} isValue={false} />
                                         </td>
                                       </WrapTable>
                                     );
@@ -250,7 +250,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                     return (
                                       <WrapTable title={item.title}>
                                         <td>
-                                          <Selectbox item={item} id={`${item.name}${index}`} isSelected={false} />
+                                          <Selectbox item={item} isSelected={false} />
                                         </td>
                                       </WrapTable>
                                     );
@@ -259,7 +259,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                     return (
                                       <WrapTable title={item.title}>
                                         <td>
-                                          <RadioButton item={item} id={`${item.name}${index}`} isChecked={false} />
+                                          <RadioButton item={item} isChecked={false} />
                                         </td>
                                       </WrapTable>
                                     );
@@ -268,7 +268,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                     return (
                                       <WrapTable title={item.title}>
                                         <td>
-                                          <Media item={item} id={`${item.name}${index}`} isValue={false} />
+                                          <Media item={item} isValue={false} />
                                         </td>
                                       </WrapTable>
                                     );
@@ -277,7 +277,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                     return (
                                       <WrapTable title={item.title}>
                                         <td>
-                                          <ImageInput item={item} id={`${item.name}${index}`} isAttribute={false} />
+                                          <ImageInput item={item} isAttribute={false} />
                                         </td>
                                       </WrapTable>
                                     );
@@ -286,7 +286,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                     return (
                                       <WrapTable title={item.title}>
                                         <td>
-                                          <RichEditor item={item} id={`${item.name}${index}`} isValue={false} />
+                                          <RichEditor item={item} isValue={false} />
                                         </td>
                                       </WrapTable>
                                     );
@@ -295,7 +295,7 @@ export const GroupTableLayout = forwardRef((_props, ref) => {
                                     return (
                                       <WrapTable title={item.title}>
                                         <td>
-                                          <Table item={item} id={`${item.name}${index}`} isValue={false} />
+                                          <Table item={item} isValue={false} />
                                         </td>
                                       </WrapTable>
                                     );

--- a/src/components/layouts/Section.jsx
+++ b/src/components/layouts/Section.jsx
@@ -156,7 +156,7 @@ export const Section = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -175,7 +175,7 @@ export const Section = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>

--- a/src/components/layouts/Section.jsx
+++ b/src/components/layouts/Section.jsx
@@ -38,14 +38,11 @@ export const Section = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <TextInput item={item} id={`${item.name}${index}`} />
+                    <TextInput item={item} />
                   </div>
                 </div>
               );
@@ -61,14 +58,11 @@ export const Section = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <Textarea item={item} id={`${item.name}${index}`} />
+                    <Textarea item={item} />
                   </div>
                 </div>
               );
@@ -83,14 +77,11 @@ export const Section = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <Selectbox item={item} id={`${item.name}${index}`} />
+                    <Selectbox item={item} />
                   </div>
                 </div>
               );
@@ -146,14 +137,11 @@ export const Section = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <Media item={item} id={`${item.name}${index}`} />
+                    <Media item={item} />
                   </div>
                 </div>
               );
@@ -168,14 +156,11 @@ export const Section = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <ImageInput item={item} id={`${item.name}${index}`} />
+                    <ImageInput item={item} />
                   </div>
                 </div>
               );
@@ -190,14 +175,11 @@ export const Section = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <FileInput item={item} id={`${item.name}${index}`} />
+                    <FileInput item={item} />
                   </div>
                 </div>
               );
@@ -212,14 +194,11 @@ export const Section = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <RichEditor item={item} id={`${item.name}${index}`} />
+                    <RichEditor item={item} />
                   </div>
                 </div>
               );
@@ -234,14 +213,11 @@ export const Section = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <Table item={item} id={`${item.name}${index}`} />
+                    <Table item={item} />
                   </div>
                 </div>
               );

--- a/src/components/layouts/Section.jsx
+++ b/src/components/layouts/Section.jsx
@@ -213,7 +213,7 @@ export const Section = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>

--- a/src/components/layouts/Section.jsx
+++ b/src/components/layouts/Section.jsx
@@ -137,7 +137,7 @@ export const Section = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -156,7 +156,7 @@ export const Section = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -175,7 +175,7 @@ export const Section = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -194,7 +194,7 @@ export const Section = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>

--- a/src/components/layouts/TableLayout.jsx
+++ b/src/components/layouts/TableLayout.jsx
@@ -35,7 +35,7 @@ export const TableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <TextInput item={item} id={`${item.name}${index}`} />
+                    <TextInput item={item} />
                   </td>
                 </tr>
               );
@@ -48,7 +48,7 @@ export const TableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <Textarea item={item} id={`${item.name}${index}`} />
+                    <Textarea item={item} />
                   </td>
                 </tr>
               );
@@ -60,7 +60,7 @@ export const TableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <Selectbox item={item} id={`${item.name}${index}`} />
+                    <Selectbox item={item} />
                   </td>
                 </tr>
               );
@@ -96,7 +96,7 @@ export const TableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <Media item={item} id={`${item.name}${index}`} />
+                    <Media item={item} />
                   </td>
                 </tr>
               );
@@ -108,7 +108,7 @@ export const TableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <ImageInput item={item} id={`${item.name}${index}`} />
+                    <ImageInput item={item} />
                   </td>
                 </tr>
               );
@@ -120,7 +120,7 @@ export const TableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <FileInput item={item} id={`${item.name}${index}`} />
+                    <FileInput item={item} />
                   </td>
                 </tr>
               );
@@ -132,7 +132,7 @@ export const TableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <RichEditor item={item} id={`${item.name}${index}`} />
+                    <RichEditor item={item} />
                   </td>
                 </tr>
               );
@@ -144,7 +144,7 @@ export const TableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <Table item={item} id={`${item.name}${index}`} />
+                    <Table item={item} />
                   </td>
                 </tr>
               );

--- a/src/components/layouts/UnitGroupSection.jsx
+++ b/src/components/layouts/UnitGroupSection.jsx
@@ -68,7 +68,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
+                        htmlFor={`${item.name}{id}`}
                       >
                         <Heading item={item} />
                       </label>
@@ -84,7 +84,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
+                        htmlFor={`${item.name}{id}`}
                       >
                         <Heading item={item} />
                       </label>
@@ -150,7 +150,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
+                        htmlFor={`${item.name}{id}`}
                       >
                         <Heading item={item} />
                       </label>
@@ -165,7 +165,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
+                        htmlFor={`${item.name}{id}`}
                       >
                         <Heading item={item} />
                       </label>
@@ -190,10 +190,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                 case 'table': {
                   return (
                     <>
-                      <label
-                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
-                      >
+                      <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -288,7 +285,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
+                                          htmlFor={`${item.name}{id}`}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -304,7 +301,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
+                                          htmlFor={`${item.name}{id}`}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -333,7 +330,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
+                                          htmlFor={`${item.name}{id}`}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -376,7 +373,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
+                                          htmlFor={`${item.name}{id}`}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -391,7 +388,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
+                                          htmlFor={`${item.name}{id}`}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -420,7 +417,6 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>

--- a/src/components/layouts/UnitGroupSection.jsx
+++ b/src/components/layouts/UnitGroupSection.jsx
@@ -148,7 +148,10 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                 case 'image': {
                   return (
                     <>
-                      <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
+                      <label
+                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
+                        htmlFor={item.name}
+                      >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -160,7 +163,10 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                 case 'file': {
                   return (
                     <>
-                      <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
+                      <label
+                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
+                        htmlFor={item.name}
+                      >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -370,6 +376,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -384,6 +391,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>

--- a/src/components/layouts/UnitGroupSection.jsx
+++ b/src/components/layouts/UnitGroupSection.jsx
@@ -136,10 +136,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                 case 'media': {
                   return (
                     <>
-                      <label
-                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
-                      >
+                      <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -151,10 +148,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                 case 'image': {
                   return (
                     <>
-                      <label
-                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
-                      >
+                      <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -166,10 +160,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                 case 'file': {
                   return (
                     <>
-                      <label
-                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
-                      >
+                      <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -181,10 +172,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                 case 'richEditor': {
                   return (
                     <>
-                      <label
-                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
-                      >
+                      <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -368,7 +356,6 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -383,7 +370,6 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -398,7 +384,6 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -413,7 +398,6 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>

--- a/src/components/layouts/UnitGroupSection.jsx
+++ b/src/components/layouts/UnitGroupSection.jsx
@@ -68,12 +68,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}${index}`}
+                        htmlFor={item.name}
                       >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <TextInput item={item} id={`${item.name}${index}`} isValue={false} />
+                        <TextInput item={item} isValue={false} />
                       </div>
                     </>
                   );
@@ -84,12 +84,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}${index}`}
+                        htmlFor={item.name}
                       >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <Textarea item={item} id={`${item.name}${index}`} isValue={false} />
+                        <Textarea item={item} isValue={false} />
                       </div>
                     </>
                   );
@@ -97,14 +97,11 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                 case 'checkbox': {
                   return (
                     <fieldset className={classnames({ 'acms-admin-contents': acmscss })}>
-                      <legend
-                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        id={`${item.name}${index}`}
-                      >
+                      <legend className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                         <Heading item={item} />
                       </legend>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <Checkbox item={item} id={`${item.name}${index}`} isChecked={false} />
+                        <Checkbox item={item} isChecked={false} />
                       </div>
                     </fieldset>
                   );
@@ -114,12 +111,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}${index}`}
+                        htmlFor={item.name}
                       >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <Selectbox item={item} id={`${item.name}${index}`} isSelected={false} />
+                        <Selectbox item={item} isSelected={false} />
                       </div>
                     </>
                   );
@@ -127,14 +124,11 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                 case 'radioButton': {
                   return (
                     <fieldset className={classnames({ 'acms-admin-contents': acmscss })}>
-                      <legend
-                        className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        id={`${item.name}${index}`}
-                      >
+                      <legend className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                         <Heading item={item} />
                       </legend>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <RadioButton item={item} id={`${item.name}${index}`} isChecked={false} />
+                        <RadioButton item={item} isChecked={false} />
                       </div>
                     </fieldset>
                   );
@@ -144,12 +138,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}${index}`}
+                        htmlFor={item.name}
                       >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <Media item={item} id={`${item.name}${index}`} isValue={false} />
+                        <Media item={item} isValue={false} />
                       </div>
                     </>
                   );
@@ -159,12 +153,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}${index}`}
+                        htmlFor={item.name}
                       >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <ImageInput item={item} id={`${item.name}${index}`} isAttribute={false} />
+                        <ImageInput item={item} isAttribute={false} />
                       </div>
                     </>
                   );
@@ -174,12 +168,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}${index}`}
+                        htmlFor={item.name}
                       >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <FileInput item={item} id={`${item.name}${index}`} isValue={false} />
+                        <FileInput item={item} isValue={false} />
                       </div>
                     </>
                   );
@@ -189,12 +183,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}${index}`}
+                        htmlFor={item.name}
                       >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <RichEditor item={item} id={`${item.name}${index}`} isValue={false} />
+                        <RichEditor item={item} isValue={false} />
                       </div>
                     </>
                   );
@@ -204,12 +198,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}${index}`}
+                        htmlFor={item.name}
                       >
                         <Heading item={item} />
                       </label>
                       <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                        <Table item={item} id={`${item.name}${index}`} isValue={false} />
+                        <Table item={item} isValue={false} />
                       </div>
                     </>
                   );
@@ -300,12 +294,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}${index}`}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <TextInput item={item} id={`${item.name}${index}`} />
+                                          <TextInput item={item} />
                                         </div>
                                       </>
                                     );
@@ -316,12 +310,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}${index}`}
+                                          htmlFor={item.name}
                                         >
-                                          <Heading item={item} id={`${item.name}${index}`} />
+                                          <Heading item={item} />
                                         </label>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <Textarea item={item} id={`${item.name}${index}`} />
+                                          <Textarea item={item} />
                                         </div>
                                       </>
                                     );
@@ -332,10 +326,10 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                         <legend
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
                                         >
-                                          <Heading item={item} id={`${item.name}${index}`} />
+                                          <Heading item={item} />
                                         </legend>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <Checkbox item={item} id={`${item.name}${index}`} />
+                                          <Checkbox item={item} />
                                         </div>
                                       </fieldset>
                                     );
@@ -345,12 +339,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}${index}`}
+                                          htmlFor={item.name}
                                         >
-                                          <Heading item={item} id={`${item.name}${index}`} />
+                                          <Heading item={item} />
                                         </label>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <Selectbox item={item} id={`${item.name}${index}`} />
+                                          <Selectbox item={item} />
                                         </div>
                                       </>
                                     );
@@ -360,12 +354,11 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <fieldset className={classnames({ 'acms-admin-contents': acmscss })}>
                                         <legend
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          id={`${item.name}${index}`}
                                         >
                                           <Heading item={item} />
                                         </legend>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <RadioButton item={item} id={`${item.name}${index}`} />
+                                          <RadioButton item={item} />
                                         </div>
                                       </fieldset>
                                     );
@@ -375,12 +368,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}${index}`}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <Media item={item} id={`${item.name}${index}`} />
+                                          <Media item={item} />
                                         </div>
                                       </>
                                     );
@@ -390,12 +383,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}${index}`}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <ImageInput item={item} id={`${item.name}${index}`} />
+                                          <ImageInput item={item} />
                                         </div>
                                       </>
                                     );
@@ -405,12 +398,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}${index}`}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
                                         <div className="acms-admin-flex-1">
-                                          <FileInput item={item} id={`${item.name}${index}`} />
+                                          <FileInput item={item} />
                                         </div>
                                       </>
                                     );
@@ -420,12 +413,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}${index}`}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <RichEditor item={item} id={`${item.name}${index}`} />
+                                          <RichEditor item={item} />
                                         </div>
                                       </>
                                     );
@@ -435,12 +428,12 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}${index}`}
+                                          htmlFor={item.name}
                                         >
                                           <Heading item={item} />
                                         </label>
                                         <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                                          <Table item={item} id={`${item.name}${index}`} />
+                                          <Table item={item} />
                                         </div>
                                       </>
                                     );

--- a/src/components/layouts/UnitGroupSection.jsx
+++ b/src/components/layouts/UnitGroupSection.jsx
@@ -68,7 +68,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}{id}`}
+                        htmlFor={`${item.name}{id}[]`}
                       >
                         <Heading item={item} />
                       </label>
@@ -84,7 +84,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}{id}`}
+                        htmlFor={`${item.name}{id}[]`}
                       >
                         <Heading item={item} />
                       </label>
@@ -111,7 +111,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={item.name}
+                        htmlFor={`${item.name}{id}[]`}
                       >
                         <Heading item={item} />
                       </label>
@@ -150,7 +150,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}{id}`}
+                        htmlFor={`${item.name}{id}[]`}
                       >
                         <Heading item={item} />
                       </label>
@@ -165,7 +165,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                     <>
                       <label
                         className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                        htmlFor={`${item.name}{id}`}
+                        htmlFor={`${item.name}{id}[]`}
                       >
                         <Heading item={item} />
                       </label>
@@ -285,7 +285,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}{id}`}
+                                          htmlFor={`${item.name}{id}[]`}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -301,7 +301,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}{id}`}
+                                          htmlFor={`${item.name}{id}[]`}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -330,7 +330,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}{id}`}
+                                          htmlFor={`${item.name}{id}[]`}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -373,7 +373,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}{id}`}
+                                          htmlFor={`${item.name}{id}[]`}
                                         >
                                           <Heading item={item} />
                                         </label>
@@ -388,7 +388,7 @@ export const UnitGroupSection = forwardRef((_props, ref) => {
                                       <>
                                         <label
                                           className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                                          htmlFor={`${item.name}{id}`}
+                                          htmlFor={`${item.name}{id}[]`}
                                         >
                                           <Heading item={item} />
                                         </label>

--- a/src/components/layouts/UnitGroupTableLayout.jsx
+++ b/src/components/layouts/UnitGroupTableLayout.jsx
@@ -84,7 +84,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                         return (
                           <WrapTable title={item.title}>
                             <td>
-                              <TextInput item={item} id={`${item.name}${index}`} />
+                              <TextInput item={item} />
                             </td>
                           </WrapTable>
                         );
@@ -94,7 +94,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                         return (
                           <WrapTable title={item.title}>
                             <td>
-                              <Textarea item={item} id={`${item.name}${index}`} />
+                              <Textarea item={item} />
                             </td>
                           </WrapTable>
                         );
@@ -103,7 +103,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                         return (
                           <WrapTable title={item.title}>
                             <td>
-                              <Checkbox item={item} id={`${item.name}${index}`} />
+                              <Checkbox item={item} />
                             </td>
                           </WrapTable>
                         );
@@ -112,7 +112,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                         return (
                           <WrapTable title={item.title}>
                             <td>
-                              <Selectbox item={item} id={`${item.name}${index}`} />
+                              <Selectbox item={item} />
                             </td>
                           </WrapTable>
                         );
@@ -121,7 +121,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                         return (
                           <WrapTable title={item.title}>
                             <td>
-                              <RadioButton item={item} id={`${item.name}${index}`} />
+                              <RadioButton item={item} />
                             </td>
                           </WrapTable>
                         );
@@ -130,7 +130,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                         return (
                           <WrapTable title={item.title}>
                             <td>
-                              <Media item={item} id={`${item.name}${index}`} />
+                              <Media item={item} />
                             </td>
                           </WrapTable>
                         );
@@ -139,7 +139,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                         return (
                           <WrapTable title={item.title}>
                             <td>
-                              <ImageInput item={item} id={`${item.name}${index}`} />
+                              <ImageInput item={item} />
                             </td>
                           </WrapTable>
                         );
@@ -161,7 +161,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                                   </div>
                                 )}
                               >
-                                <RichEditor item={item} id={`${item.name}${index}`} />
+                                <RichEditor item={item} />
                               </ConditionalWrap>
                             </td>
                           </WrapTable>
@@ -171,7 +171,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                         return (
                           <WrapTable title={item.title}>
                             <td>
-                              <Table item={item} id={`${item.name}${index}`} />
+                              <Table item={item} />
                             </td>
                           </WrapTable>
                         );
@@ -222,7 +222,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                             return (
                               <WrapTable title={item.title}>
                                 <td>
-                                  <TextInput item={item} id={`${item.name}${index}`} isValue={false} />
+                                  <TextInput item={item} isValue={false} />
                                 </td>
                               </WrapTable>
                             );
@@ -232,7 +232,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                             return (
                               <WrapTable title={item.title}>
                                 <td>
-                                  <Textarea item={item} id={`${item.name}${index}`} isValue={false} />
+                                  <Textarea item={item} isValue={false} />
                                 </td>
                               </WrapTable>
                             );
@@ -250,7 +250,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                             return (
                               <WrapTable title={item.title}>
                                 <td>
-                                  <Selectbox item={item} id={`${item.name}${index}`} isSelected={false} />
+                                  <Selectbox item={item} isSelected={false} />
                                 </td>
                               </WrapTable>
                             );
@@ -259,7 +259,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                             return (
                               <WrapTable title={item.title}>
                                 <td>
-                                  <RadioButton item={item} id={`${item.name}${index}`} isChecked={false} />
+                                  <RadioButton item={item} isChecked={false} />
                                 </td>
                               </WrapTable>
                             );
@@ -268,7 +268,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                             return (
                               <WrapTable title={item.title}>
                                 <td>
-                                  <Media item={item} id={`${item.name}${index}`} isValue={false} />
+                                  <Media item={item} isValue={false} />
                                 </td>
                               </WrapTable>
                             );
@@ -277,7 +277,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                             return (
                               <WrapTable title={item.title}>
                                 <td>
-                                  <ImageInput item={item} id={`${item.name}${index}`} isAttribute={false} />
+                                  <ImageInput item={item} isAttribute={false} />
                                 </td>
                               </WrapTable>
                             );
@@ -286,7 +286,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                             return (
                               <WrapTable title={item.title}>
                                 <td>
-                                  <RichEditor item={item} id={`${item.name}${index}`} isValue={false} />
+                                  <RichEditor item={item} isValue={false} />
                                 </td>
                               </WrapTable>
                             );
@@ -295,7 +295,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                             return (
                               <WrapTable title={item.title}>
                                 <td>
-                                  <Table item={item} id={`${item.name}${index}`} isValue={false} />
+                                  <Table item={item} isValue={false} />
                                 </td>
                               </WrapTable>
                             );

--- a/src/components/layouts/UnitGroupTableLayout.jsx
+++ b/src/components/layouts/UnitGroupTableLayout.jsx
@@ -74,7 +74,7 @@ export const UnitGroupTableLayout = forwardRef((_props, ref) => {
                     </td>
                   )}
                 >
-                  {unitgroup.items.map((item, index) => {
+                  {unitgroup.items.map((item) => {
                     switch (item.type) {
                       case 'text':
                       case 'tel':

--- a/src/components/layouts/UnitSection.jsx
+++ b/src/components/layouts/UnitSection.jsx
@@ -38,7 +38,10 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
+                  <label
+                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
+                    htmlFor={`${item.name}{id}`}
+                  >
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -58,7 +61,10 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
+                  <label
+                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
+                    htmlFor={`${item.name}{id}`}
+                  >
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -77,7 +83,10 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
+                  <label
+                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
+                    htmlFor={`${item.name}{id}`}
+                  >
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -156,7 +165,10 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
+                  <label
+                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
+                    htmlFor={`${item.name}{id}`}
+                  >
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -175,7 +187,10 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
+                  <label
+                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
+                    htmlFor={`${item.name}{id}`}
+                  >
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>

--- a/src/components/layouts/UnitSection.jsx
+++ b/src/components/layouts/UnitSection.jsx
@@ -38,14 +38,11 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <TextInput item={item} id={`${item.name}${index}`} />
+                    <TextInput item={item} />
                   </div>
                 </div>
               );
@@ -61,14 +58,11 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <Textarea item={item} id={`${item.name}${index}`} />
+                    <Textarea item={item} />
                   </div>
                 </div>
               );
@@ -83,14 +77,11 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <Selectbox item={item} id={`${item.name}${index}`} />
+                    <Selectbox item={item} />
                   </div>
                 </div>
               );
@@ -146,14 +137,11 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <Media item={item} id={`${item.name}${index}`} />
+                    <Media item={item} />
                   </div>
                 </div>
               );
@@ -168,14 +156,11 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <ImageInput item={item} id={`${item.name}${index}`} />
+                    <ImageInput item={item} />
                   </div>
                 </div>
               );
@@ -190,14 +175,11 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <FileInput item={item} id={`${item.name}${index}`} />
+                    <FileInput item={item} />
                   </div>
                 </div>
               );
@@ -212,14 +194,11 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <RichEditor item={item} id={`${item.name}${index}`} />
+                    <RichEditor item={item} />
                   </div>
                 </div>
               );
@@ -234,14 +213,11 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label
-                    className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}
-                    htmlFor={`${item.name}${index}`}
-                  >
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
-                    <Table item={item} id={`${item.name}${index}`} />
+                    <Table item={item} />
                   </div>
                 </div>
               );

--- a/src/components/layouts/UnitSection.jsx
+++ b/src/components/layouts/UnitSection.jsx
@@ -137,7 +137,7 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -156,7 +156,7 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -175,7 +175,7 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -194,7 +194,7 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>

--- a/src/components/layouts/UnitSection.jsx
+++ b/src/components/layouts/UnitSection.jsx
@@ -156,7 +156,7 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>
@@ -175,7 +175,7 @@ export const UnitSection = forwardRef((_props, ref) => {
                     'acms-admin-flex-row-min-md': acmscss,
                   })}
                 >
-                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })}>
+                  <label className={classnames({ 'acms-admin-grid-edit-table-heading': acmscss })} htmlFor={item.name}>
                     <Heading item={item} />
                   </label>
                   <div className={classnames({ 'acms-admin-flex-1': acmscss })}>

--- a/src/components/layouts/UnitTableLayout.jsx
+++ b/src/components/layouts/UnitTableLayout.jsx
@@ -35,7 +35,7 @@ export const UnitTableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <TextInput item={item} id={`${item.name}${index}`} />
+                    <TextInput item={item} />
                   </td>
                 </tr>
               );
@@ -48,7 +48,7 @@ export const UnitTableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <Textarea item={item} id={`${item.name}${index}`} />
+                    <Textarea item={item} />
                   </td>
                 </tr>
               );
@@ -60,7 +60,7 @@ export const UnitTableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <Selectbox item={item} id={`${item.name}${index}`} />
+                    <Selectbox item={item} />
                   </td>
                 </tr>
               );
@@ -96,7 +96,7 @@ export const UnitTableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <Media item={item} id={`${item.name}${index}`} />
+                    <Media item={item} />
                   </td>
                 </tr>
               );
@@ -108,7 +108,7 @@ export const UnitTableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <ImageInput item={item} id={`${item.name}${index}`} />
+                    <ImageInput item={item} />
                   </td>
                 </tr>
               );
@@ -120,7 +120,7 @@ export const UnitTableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <FileInput item={item} id={`${item.name}${index}`} />
+                    <FileInput item={item} />
                   </td>
                 </tr>
               );
@@ -132,7 +132,7 @@ export const UnitTableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <RichEditor item={item} id={`${item.name}${index}`} />
+                    <RichEditor item={item} />
                   </td>
                 </tr>
               );
@@ -144,7 +144,7 @@ export const UnitTableLayout = forwardRef((_props, ref) => {
                     <Heading item={item} />
                   </th>
                   <td>
-                    <Table item={item} id={`${item.name}${index}`} />
+                    <Table item={item} />
                   </td>
                 </tr>
               );

--- a/src/constants/index.js
+++ b/src/constants/index.js
@@ -1,0 +1,1 @@
+export const STORAGENAME = 'custom_field_maker';

--- a/src/containers/index.jsx
+++ b/src/containers/index.jsx
@@ -51,50 +51,64 @@ function CustomFieldMaker() {
               <div className="clearfix">
                 <PreviewNavigator />
 
-                {preview.editMode === 'source' && (
-                  <Highlighter onHighlight={onSource}>
-                    <MakerContextProvider state={state} preview={preview} clipboard={clipboard}>
+                <ul>
+                  <li
+                    style={{
+                      display: preview.editMode === 'source' ? 'block' : 'none',
+                    }}
+                  >
+                    <Highlighter onHighlight={onSource}>
+                      <MakerContextProvider state={state} preview={preview} clipboard={clipboard}>
+                        {{
+                          customfield: <FieldSource />,
+                          fieldgroup: <FieldGroupSource />,
+                          customunit: <UnitSource />,
+                          unitgroup: <UnitGroupSource />,
+                        }[preview.mode] || null}
+                      </MakerContextProvider>
+                    </Highlighter>
+                  </li>
+
+                  <li
+                    style={{
+                      display: preview.editMode === 'preview' ? 'block' : 'none',
+                    }}
+                  >
+                    <div
+                      style={{
+                        borderRadius: '5px',
+                        padding: '20px',
+                        margin: '1em 0',
+                        backgroundColor: '#F0F0F0',
+                        minHeight: '19.391px',
+                      }}
+                    >
                       {{
                         customfield: <FieldSource />,
                         fieldgroup: <FieldGroupSource />,
                         customunit: <UnitSource />,
                         unitgroup: <UnitGroupSource />,
                       }[preview.mode] || null}
-                    </MakerContextProvider>
-                  </Highlighter>
-                )}
+                    </div>
+                  </li>
 
-                {preview.editMode === 'preview' && (
-                  <div
+                  <li
                     style={{
-                      borderRadius: '5px',
-                      padding: '20px',
-                      margin: '1em 0',
-                      backgroundColor: '#F0F0F0',
-                      minHeight: '19.391px',
+                      display: preview.editMode === 'confirm' ? 'block' : 'none',
                     }}
                   >
-                    {{
-                      customfield: <FieldSource />,
-                      fieldgroup: <FieldGroupSource />,
-                      customunit: <UnitSource />,
-                      unitgroup: <UnitGroupSource />,
-                    }[preview.mode] || null}
-                  </div>
-                )}
-
-                {preview.editMode === 'confirm' && (
-                  <Highlighter onHighlight={onSource}>
-                    <MakerContextProvider state={state} preview={preview} clipboard={clipboard}>
-                      {{
-                        customfield: <FieldConfirmSource />,
-                        fieldgroup: <FieldGroupConfirmSource />,
-                        customunit: <UnitConfirmSource />,
-                        unitgroup: <UnitGroupConfirmSource />,
-                      }[preview.mode] || null}
-                    </MakerContextProvider>
-                  </Highlighter>
-                )}
+                    <Highlighter onHighlight={onSource}>
+                      <MakerContextProvider state={state} preview={preview} clipboard={clipboard}>
+                        {{
+                          customfield: <FieldConfirmSource />,
+                          fieldgroup: <FieldGroupConfirmSource />,
+                          customunit: <UnitConfirmSource />,
+                          unitgroup: <UnitGroupConfirmSource />,
+                        }[preview.mode] || null}
+                      </MakerContextProvider>
+                    </Highlighter>
+                  </li>
+                </ul>
               </div>
             </div>
           </div>

--- a/src/containers/index.jsx
+++ b/src/containers/index.jsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { MakerContextProvider, useMakerContext } from '../store/MakerContext';
 import { EditorModeNavigator } from '../components/navigator/EditorModeNavigator';
 import { PreviewModeNavigator } from '../components/navigator/PreviewModeNavigator';
@@ -17,6 +17,7 @@ import { UnitConfirmSource } from '../components/UnitConfirmSource';
 import { UnitGroupConfirmSource } from '../components/UnitGroupConfirmSource';
 import { Highlighter } from '../components/Highlighter';
 import { decode } from 'html-entities';
+import { STORAGENAME } from '../constants';
 
 function CustomFieldMaker() {
   const { setSource, state, preview, clipboard } = useMakerContext();
@@ -27,6 +28,10 @@ function CustomFieldMaker() {
       setSource(decodedHtml);
     }
   };
+
+  useEffect(() => {
+    localStorage.setItem(STORAGENAME, JSON.stringify(state));
+  }, [state]);
 
   return (
     <div className="customFieldContainer acms-admin-form">

--- a/src/containers/index.jsx
+++ b/src/containers/index.jsx
@@ -56,7 +56,12 @@ function CustomFieldMaker() {
               <div className="clearfix">
                 <PreviewNavigator />
 
-                <ul>
+                <ul
+                  style={{
+                    padding: '16px 0',
+                    margin: '0',
+                  }}
+                >
                   <li
                     style={{
                       display: preview.editMode === 'source' ? 'block' : 'none',
@@ -81,11 +86,10 @@ function CustomFieldMaker() {
                   >
                     <div
                       style={{
-                        borderRadius: '5px',
-                        padding: '20px',
-                        margin: '1em 0',
+                        padding: '16px',
+                        margin: '0',
                         backgroundColor: '#F0F0F0',
-                        minHeight: '19.391px',
+                        minHeight: '18.398px',
                       }}
                     >
                       {{

--- a/src/containers/index.jsx
+++ b/src/containers/index.jsx
@@ -67,16 +67,18 @@ function CustomFieldMaker() {
                       display: preview.editMode === 'source' ? 'block' : 'none',
                     }}
                   >
-                    <Highlighter onHighlight={onSource}>
-                      <MakerContextProvider state={state} preview={preview} clipboard={clipboard}>
-                        {{
-                          customfield: <FieldSource />,
-                          fieldgroup: <FieldGroupSource />,
-                          customunit: <UnitSource />,
-                          unitgroup: <UnitGroupSource />,
-                        }[preview.mode] || null}
-                      </MakerContextProvider>
-                    </Highlighter>
+                    {preview.editMode === 'source' && (
+                      <Highlighter onHighlight={onSource}>
+                        <MakerContextProvider state={state} preview={preview} clipboard={clipboard}>
+                          {{
+                            customfield: <FieldSource />,
+                            fieldgroup: <FieldGroupSource />,
+                            customunit: <UnitSource />,
+                            unitgroup: <UnitGroupSource />,
+                          }[preview.mode] || null}
+                        </MakerContextProvider>
+                      </Highlighter>
+                    )}
                   </li>
 
                   <li
@@ -106,16 +108,18 @@ function CustomFieldMaker() {
                       display: preview.editMode === 'confirm' ? 'block' : 'none',
                     }}
                   >
-                    <Highlighter onHighlight={onSource}>
-                      <MakerContextProvider state={state} preview={preview} clipboard={clipboard}>
-                        {{
-                          customfield: <FieldConfirmSource />,
-                          fieldgroup: <FieldGroupConfirmSource />,
-                          customunit: <UnitConfirmSource />,
-                          unitgroup: <UnitGroupConfirmSource />,
-                        }[preview.mode] || null}
-                      </MakerContextProvider>
-                    </Highlighter>
+                    {preview.editMode === 'confirm' && (
+                      <Highlighter onHighlight={onSource}>
+                        <MakerContextProvider state={state} preview={preview} clipboard={clipboard}>
+                          {{
+                            customfield: <FieldConfirmSource />,
+                            fieldgroup: <FieldGroupConfirmSource />,
+                            customunit: <UnitConfirmSource />,
+                            unitgroup: <UnitGroupConfirmSource />,
+                          }[preview.mode] || null}
+                        </MakerContextProvider>
+                      </Highlighter>
+                    )}
                   </li>
                 </ul>
               </div>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -4,7 +4,7 @@ import { MakerContextProvider } from './store/MakerContext';
 import { STORAGENAME } from './constants';
 
 function App() {
-  const state = JSON.parse(localStorage.getItem(STORAGENAME));
+  const state = JSON.parse(localStorage.getItem(STORAGENAME)) || undefined;
 
   return (
     <MakerContextProvider state={state}>

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,11 +1,16 @@
 import React from 'react';
 import CustomFieldMaker from './containers';
 import { MakerContextProvider } from './store/MakerContext';
+import { STORAGENAME } from './constants';
 
 function App() {
-  return <MakerContextProvider>
+  const state = JSON.parse(localStorage.getItem(STORAGENAME));
+
+  return (
+    <MakerContextProvider state={state}>
       <CustomFieldMaker />
     </MakerContextProvider>
+  );
 }
 
-export default App
+export default App;

--- a/src/store/MakerContext.js
+++ b/src/store/MakerContext.js
@@ -60,7 +60,6 @@ export const MakerContext = createContext({
   setAcmscss: () => {},
   setJsValidator: () => {},
   setDirection: () => {},
-  setStateAll: () => {},
 });
 
 export function MakerContextProvider({
@@ -81,14 +80,6 @@ export function MakerContextProvider({
       }),
     [dispatch]
   );
-  const setCustomfield = useCallback(
-    (setCustomfield) =>
-      dispatch({
-        type: 'UPDATE_STATE',
-        payload: { customfield: () => [setCustomfield] },
-      }),
-    [dispatch]
-  );
 
   const addCustomunit = useCallback(
     (newCustomunit) =>
@@ -97,14 +88,6 @@ export function MakerContextProvider({
         payload: { customunit: [...state.customunit, newCustomunit] },
       }),
     [dispatch, state.customunit]
-  );
-  const setCustomunit = useCallback(
-    (setCustomunit) =>
-      dispatch({
-        type: 'UPDATE_STATE',
-        payload: { customunit: [setCustomunit] },
-      }),
-    [dispatch]
   );
 
   const setGroupTitleName = useCallback(
@@ -125,16 +108,6 @@ export function MakerContextProvider({
       }),
     [dispatch]
   );
-  const setGroupItem = useCallback(
-    (setGroupItem) =>
-      dispatch({
-        type: 'UPDATE_STATE',
-        payload: {
-          fieldgroup: (prevFieldgroup) => ({ ...prevFieldgroup, items: [setGroupItem] }),
-        },
-      }),
-    [dispatch]
-  );
 
   const setUnitGroupTitleName = useCallback(
     (title, name) =>
@@ -151,26 +124,6 @@ export function MakerContextProvider({
         payload: { unitgroup: { ...state.unitgroup, items: [...state.unitgroup.items, newGroupItem] } },
       }),
     [dispatch, state.unitgroup]
-  );
-  const setUnitGroupItem = useCallback(
-    (setGroupItem) =>
-      dispatch({
-        type: 'UPDATE_STATE',
-        payload: { unitgroup: { ...state.unitgroup, items: [setGroupItem] } },
-      }),
-    [dispatch, state.unitgroup]
-  );
-
-  const setAllState = useCallback(
-    (state) => {
-      setCustomfield(state.customfield);
-      setCustomunit(state.customunit);
-      setGroupTitleName(state.fieldgroup.title, state.fieldgroup.name);
-      setGroupItem(state.fieldgroup.items);
-      setUnitGroupTitleName(state.unitgroup.title, state.unitgroup.name);
-      setUnitGroupItem(state.unitgroup.items);
-    },
-    [setCustomfield, setCustomunit, setGroupTitleName, setGroupItem, setUnitGroupTitleName, setUnitGroupItem]
   );
 
   const clearCustomfield = useCallback(
@@ -261,7 +214,6 @@ export function MakerContextProvider({
       setCopied,
       undo,
       redo,
-      setAllState,
     }),
     [
       state,
@@ -289,7 +241,6 @@ export function MakerContextProvider({
       setCopied,
       undo,
       redo,
-      setAllState,
     ]
   );
 

--- a/src/store/MakerContext.js
+++ b/src/store/MakerContext.js
@@ -60,6 +60,7 @@ export const MakerContext = createContext({
   setAcmscss: () => {},
   setJsValidator: () => {},
   setDirection: () => {},
+  setStateAll: () => {},
 });
 
 export function MakerContextProvider({
@@ -80,11 +81,32 @@ export function MakerContextProvider({
       }),
     [dispatch]
   );
+  const setCustomfield = useCallback(
+    (setCustomfield) =>
+      dispatch({
+        type: 'UPDATE_STATE',
+        payload: { customfield: () => [setCustomfield] },
+      }),
+    [dispatch]
+  );
+
   const addCustomunit = useCallback(
     (newCustomunit) =>
-      dispatch({ type: 'UPDATE_STATE', payload: { customunit: [...state.customunit, newCustomunit] } }),
+      dispatch({
+        type: 'UPDATE_STATE',
+        payload: { customunit: [...state.customunit, newCustomunit] },
+      }),
     [dispatch, state.customunit]
   );
+  const setCustomunit = useCallback(
+    (setCustomunit) =>
+      dispatch({
+        type: 'UPDATE_STATE',
+        payload: { customunit: [setCustomunit] },
+      }),
+    [dispatch]
+  );
+
   const setGroupTitleName = useCallback(
     (title, name) =>
       dispatch({
@@ -103,8 +125,23 @@ export function MakerContextProvider({
       }),
     [dispatch]
   );
+  const setGroupItem = useCallback(
+    (setGroupItem) =>
+      dispatch({
+        type: 'UPDATE_STATE',
+        payload: {
+          fieldgroup: (prevFieldgroup) => ({ ...prevFieldgroup, items: [setGroupItem] }),
+        },
+      }),
+    [dispatch]
+  );
+
   const setUnitGroupTitleName = useCallback(
-    (title, name) => dispatch({ type: 'UPDATE_STATE', payload: { unitgroup: { ...state.unitgroup, title, name } } }),
+    (title, name) =>
+      dispatch({
+        type: 'UPDATE_STATE',
+        payload: { unitgroup: { ...state.unitgroup, title, name } },
+      }),
     [dispatch, state.unitgroup]
   );
   const addUnitGroupItem = useCallback(
@@ -114,6 +151,26 @@ export function MakerContextProvider({
         payload: { unitgroup: { ...state.unitgroup, items: [...state.unitgroup.items, newGroupItem] } },
       }),
     [dispatch, state.unitgroup]
+  );
+  const setUnitGroupItem = useCallback(
+    (setGroupItem) =>
+      dispatch({
+        type: 'UPDATE_STATE',
+        payload: { unitgroup: { ...state.unitgroup, items: [setGroupItem] } },
+      }),
+    [dispatch, state.unitgroup]
+  );
+
+  const setAllState = useCallback(
+    (state) => {
+      setCustomfield(state.customfield);
+      setCustomunit(state.customunit);
+      setGroupTitleName(state.fieldgroup.title, state.fieldgroup.name);
+      setGroupItem(state.fieldgroup.items);
+      setUnitGroupTitleName(state.unitgroup.title, state.unitgroup.name);
+      setUnitGroupItem(state.unitgroup.items);
+    },
+    [setCustomfield, setCustomunit, setGroupTitleName, setGroupItem, setUnitGroupTitleName, setUnitGroupItem]
   );
 
   const clearCustomfield = useCallback(
@@ -204,6 +261,7 @@ export function MakerContextProvider({
       setCopied,
       undo,
       redo,
+      setAllState,
     }),
     [
       state,
@@ -231,6 +289,7 @@ export function MakerContextProvider({
       setCopied,
       undo,
       redo,
+      setAllState,
     ]
   );
 

--- a/src/utils/index.jsx
+++ b/src/utils/index.jsx
@@ -1,0 +1,6 @@
+export function generateSafeId(input) {
+  return btoa(encodeURI(encodeURIComponent(input)))
+    .replace(/=/g, '') // = 記号を除去
+    .replace(/\+/g, '-') // + をハイフンに置換
+    .replace(/\//g, '_'); // / をアンダースコアに置換
+}

--- a/webpack.dev.js
+++ b/webpack.dev.js
@@ -23,4 +23,9 @@ module.exports = merge(prodConfig, {
       filename: 'index.html',
     }),
   ],
+  watchOptions: {
+    ignored: '**/node_modules/**',
+    aggregateTimeout: 300,
+    poll: 1000,
+  },
 });


### PR DESCRIPTION
- 生成コード履歴をlocalStorageに残す機能を追加
- メディアを生成した時、プレビュータブを切り替えると毎回 js-media が発火する問題を修正
- コードコピー時の吹き出しが他の要素に被る問題を修正
- 生成されるフィールドの ID を `[カスタムフィールド名]-[値をエスケープしたもの]` に修正
- バリデーターを追加したときにオプションが見切れる問題を、アコーディオンの実装方法を見直すことで修正
